### PR TITLE
AA-110-check-codehash

### DIFF
--- a/.idea/aa-bundler.iml
+++ b/.idea/aa-bundler.iml
@@ -11,6 +11,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/utils/cache" />
       <excludeFolder url="file://$MODULE_DIR$/packages/utils/dist" />
       <excludeFolder url="file://$MODULE_DIR$/packages/bundler/src/types" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/bundler/deployments" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/bundler/.depcheckrc
+++ b/packages/bundler/.depcheckrc
@@ -1,1 +1,0 @@
-ignores: ["solidity-string-utils"]

--- a/packages/bundler/contracts/BundlerHelper.sol
+++ b/packages/bundler/contracts/BundlerHelper.sol
@@ -1,35 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.15;
 
-
-contract Config {
-
-    uint public immutable val;
-    constructor(ConfigFactory f) {
-        try f.val() returns (uint _val) {
-            val = _val;
-        } catch {
-//            val = 0;
-        }
-    }
-    function destruct() public {
-        selfdestruct(payable(msg.sender));
-    }
-}
-
-contract ConfigFactory {
-    uint public val;
-    Config public cfg = new Config{salt : 0}(this);
-
-    //return config object: always on the same address, but with different code..
-    function getConfig(uint _val) public returns (Config){
-        cfg.destruct();
-        val = _val;
-        return new Config{salt : 0}(this);
-    }
-}
+import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
 contract BundlerHelper {
+    function getUserOpHashes(IEntryPoint entryPoint, UserOperation[] memory userOps) external view returns (bytes32[] memory ret) {
+        ret = new bytes32[](userOps.length);
+        for (uint i = 0; i < userOps.length; i++) {
+            ret[i] = entryPoint.getUserOpHash(userOps[i]);
+        }
+    }
+
     function getCodeHashes(address[] memory addresses) public view returns (bytes32) {
         bytes32[] memory hashes = new bytes32[](addresses.length);
         for (uint i = 0; i < addresses.length; i++) {

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -56,7 +56,6 @@
     "hardhat": "^2.11.0",
     "hardhat-deploy": "^0.11.11",
     "solidity-coverage": "^0.7.21",
-    "solidity-string-utils": "^0.0.8-0",
     "ts-node": ">=8.0.0",
     "typechain": "^8.1.0"
   }

--- a/packages/bundler/src/BundlerConfig.ts
+++ b/packages/bundler/src/BundlerConfig.ts
@@ -4,6 +4,7 @@ import ow from 'ow'
 export interface BundlerConfig {
   beneficiary: string
   entryPoint: string
+  bundlerHelper: string
   gasFactor: string
   minBalance: string
   mnemonic: string
@@ -24,6 +25,7 @@ export interface BundlerConfig {
 export const BundlerConfigShape = {
   beneficiary: ow.string,
   entryPoint: ow.string,
+  bundlerHelper: ow.string,
   gasFactor: ow.string,
   minBalance: ow.string,
   mnemonic: ow.string,
@@ -45,5 +47,6 @@ export const BundlerConfigShape = {
 export const bundlerConfigDefault: Partial<BundlerConfig> = {
   port: '3000',
   entryPoint: '0x1306b01bC3e4AD202612D3843387e94737673F53',
+  bundlerHelper: '0x3ac2913fd3ed9a2c6eb7757bcfc6f9cd49cbfea4',
   unsafe: false
 }

--- a/packages/bundler/src/BundlerServer.ts
+++ b/packages/bundler/src/BundlerServer.ts
@@ -171,8 +171,7 @@ export class BundlerServer {
         result = 'ok'
         break
       case 'debug_bundler_sendBundleNow':
-        await this.debugHandler.sendBundleNow()
-        result = 'ok'
+        result = await this.debugHandler.sendBundleNow()
         break
       default:
         throw new RpcError(`Method ${method} is not supported`, -32601)

--- a/packages/bundler/src/DebugMethodHandler.ts
+++ b/packages/bundler/src/DebugMethodHandler.ts
@@ -1,6 +1,7 @@
 import { ExecutionManager } from './modules/ExecutionManager'
 import { ReputationDump, ReputationManager } from './modules/ReputationManager'
 import { MempoolManager } from './modules/MempoolManager'
+import { SendBundleReturn } from './modules/BundleManager'
 
 export class DebugMethodHandler {
   constructor (
@@ -29,8 +30,8 @@ export class DebugMethodHandler {
     }
   }
 
-  async sendBundleNow (): Promise<void> {
-    await this.execManager.attemptBundle(true)
+  async sendBundleNow (): Promise<SendBundleReturn | undefined> {
+    return await this.execManager.attemptBundle(true)
   }
 
   clearState (): void {

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -119,9 +119,9 @@ export class BundleManager {
       let validationResult: ValidationResult
       try {
         // re-validate UserOp. no need to check stake, since it cannot be reduced between first and 2nd validation
-        validationResult = await this.validationManager.validateUserOp(entry.userOp, false)
+        validationResult = await this.validationManager.validateUserOp(entry.userOp, entry.referencedContracts, false)
       } catch (e: any) {
-        debug('failed 2nd validation', e.message)
+        debug('failed 2nd validation:', e.message)
         // failed validation. don't try anymore
         this.mempoolManager.removeUserOp(entry.userOp)
         continue

--- a/packages/bundler/src/modules/ExecutionManager.ts
+++ b/packages/bundler/src/modules/ExecutionManager.ts
@@ -1,7 +1,7 @@
 import { ReputationManager } from './ReputationManager'
 import { clearInterval } from 'timers'
 import { MempoolManager } from './MempoolManager'
-import { BundleManager } from './BundleManager'
+import { BundleManager, SendBundleReturn } from './BundleManager'
 import Debug from 'debug'
 import { UserOperation } from './moduleUtils'
 import { ValidationManager } from './ValidationManager'
@@ -81,10 +81,10 @@ export class ExecutionManager {
    * attempt to send a bundle now.
    * @param force
    */
-  async attemptBundle (force = true): Promise<void> {
+  async attemptBundle (force = true): Promise<SendBundleReturn | undefined> {
     debug('attemptBundle force=', force, 'count=', this.mempoolManager.count(), 'max=', this.maxMempoolSize)
     if (force || this.mempoolManager.count() >= this.maxMempoolSize) {
-      await this.bundleManager.sendNextBundle()
+      return await this.bundleManager.sendNextBundle()
     }
   }
 }

--- a/packages/bundler/src/modules/ExecutionManager.ts
+++ b/packages/bundler/src/modules/ExecutionManager.ts
@@ -39,10 +39,11 @@ export class ExecutionManager {
     await this.mutex.runExclusive(async () => {
       debug('sendUserOperation')
       this.validationManager.validateInputParameters(userOp, entryPointInput)
-      const validationResult = await this.validationManager.validateUserOp(userOp)
+      const validationResult = await this.validationManager.validateUserOp(userOp, undefined)
       this.mempoolManager.addUserOp(userOp,
         validationResult.returnInfo.prefund,
         validationResult.senderInfo,
+        validationResult.referencedContracts,
         validationResult.aggregatorInfo?.addr)
       await this.attemptBundle(false)
     })

--- a/packages/bundler/src/modules/MempoolManager.ts
+++ b/packages/bundler/src/modules/MempoolManager.ts
@@ -1,7 +1,7 @@
 import { BigNumber, BigNumberish } from 'ethers'
 import { getAddr, UserOperation } from './moduleUtils'
 import { requireCond } from '../utils'
-import { StakeInfo, ValidationErrors } from './ValidationManager'
+import { ReferencedCodeHashes, StakeInfo, ValidationErrors } from './ValidationManager'
 import { ReputationManager } from './ReputationManager'
 import Debug from 'debug'
 
@@ -10,6 +10,7 @@ const debug = Debug('aa.mempool')
 export interface MempoolEntry {
   userOp: UserOperation
   prefund: BigNumberish
+  referencedContracts: ReferencedCodeHashes
   // aggregator, if one was found during simulation
   aggregator?: string
 }
@@ -35,10 +36,11 @@ export class MempoolManager {
   // add userOp into the mempool, after initial validation.
   // replace existing, if any (and if new gas is higher)
   // revets if unable to add UserOp to mempool (too many UserOps with this sender)
-  addUserOp (userOp: UserOperation, prefund: BigNumberish, senderInfo: StakeInfo, aggregator?: string): void {
+  addUserOp (userOp: UserOperation, prefund: BigNumberish, senderInfo: StakeInfo, referencedContracts: ReferencedCodeHashes, aggregator?: string): void {
     const entry: MempoolEntry = {
       userOp,
       prefund,
+      referencedContracts,
       aggregator
     }
     const index = this._find(userOp)

--- a/packages/bundler/src/modules/initServer.ts
+++ b/packages/bundler/src/modules/initServer.ts
@@ -22,7 +22,7 @@ export function initServer (config: BundlerConfig, signer: Signer): [ExecutionMa
   const reputationManager = new ReputationManager(BundlerReputationParams, parseEther(config.minStake), config.minUnstakeDelay)
   const mempoolManager = new MempoolManager(reputationManager)
   const validationManager = new ValidationManager(entryPoint, bundlerHelper, reputationManager, config.unsafe)
-  const bundleManager = new BundleManager(entryPoint, mempoolManager, validationManager, reputationManager, config.beneficiary, parseEther(config.minBalance), config.maxBundleGas)
+  const bundleManager = new BundleManager(entryPoint, bundlerHelper, mempoolManager, validationManager, reputationManager, config.beneficiary, parseEther(config.minBalance), config.maxBundleGas)
   const eventsManager = new EventsManager(entryPoint, reputationManager)
   const executionManager = new ExecutionManager(reputationManager, mempoolManager, bundleManager, validationManager)
 

--- a/packages/bundler/src/modules/initServer.ts
+++ b/packages/bundler/src/modules/initServer.ts
@@ -8,6 +8,7 @@ import { parseEther } from 'ethers/lib/utils'
 import { Signer } from 'ethers'
 import { BundlerConfig } from '../BundlerConfig'
 import { EventsManager } from './EventsManager'
+import { BundlerHelper__factory } from '../types'
 
 /**
  * initialize server modules.
@@ -17,9 +18,10 @@ import { EventsManager } from './EventsManager'
  */
 export function initServer (config: BundlerConfig, signer: Signer): [ExecutionManager, EventsManager, ReputationManager, MempoolManager] {
   const entryPoint = EntryPoint__factory.connect(config.entryPoint, signer)
+  const bundlerHelper = BundlerHelper__factory.connect(config.bundlerHelper, signer)
   const reputationManager = new ReputationManager(BundlerReputationParams, parseEther(config.minStake), config.minUnstakeDelay)
   const mempoolManager = new MempoolManager(reputationManager)
-  const validationManager = new ValidationManager(entryPoint, reputationManager, config.unsafe)
+  const validationManager = new ValidationManager(entryPoint, bundlerHelper, reputationManager, config.unsafe)
   const bundleManager = new BundleManager(entryPoint, mempoolManager, validationManager, reputationManager, config.beneficiary, parseEther(config.minBalance), config.maxBundleGas)
   const eventsManager = new EventsManager(entryPoint, reputationManager)
   const executionManager = new ExecutionManager(reputationManager, mempoolManager, bundleManager, validationManager)

--- a/packages/bundler/src/parseScannerResult.ts
+++ b/packages/bundler/src/parseScannerResult.ts
@@ -176,8 +176,9 @@ function parseEntitySlots (stakeInfoEntities: { [addr: string]: StakeInfo | unde
  * @param tracerResults the tracer return value
  * @param validationResult output from simulateValidation
  * @param entryPoint the entryPoint that hosted the "simulatedValidation" traced call.
+ * @return list of contract addresses referenced by this UserOp
  */
-export function parseScannerResult (userOp: UserOperation, tracerResults: BundlerCollectorReturn, validationResult: ValidationResult, entryPoint: EntryPoint): void {
+export function parseScannerResult (userOp: UserOperation, tracerResults: BundlerCollectorReturn, validationResult: ValidationResult, entryPoint: EntryPoint): string[] {
   debug('=== simulation result:', inspect(tracerResults, true, 10, true))
   // todo: block access to no-code addresses (might need update to tracer)
 
@@ -341,5 +342,12 @@ export function parseScannerResult (userOp: UserOperation, tracerResults: Bundle
 
       // TODO: check real minimum stake values
     }
+
+    requireCond(Object.keys(currentNumLevel.contractSize).find(addr => currentNumLevel.contractSize[addr] <= 2) == null,
+      `${entityTitle} accesses un-deployed contract ${JSON.stringify(currentNumLevel.contractSize)}`)
   })
+
+  // return list of contract addresses by this UserOp. already known not to contain zero-sized addresses.
+  const addresses = tracerResults.numberLevels.flatMap(level => Object.keys(level.contractSize))
+  return addresses
 }

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -15,6 +15,7 @@ import { initServer } from './modules/initServer'
 import { DebugMethodHandler } from './DebugMethodHandler'
 import { DeterministicDeployer } from '@account-abstraction/sdk'
 import { isGeth } from './utils'
+import { BundlerHelper__factory } from './types'
 
 // this is done so that console.log outputs BigNumber as hex string instead of unreadable object
 export const inspectCustomSymbol = Symbol.for('nodejs.util.inspect.custom')
@@ -149,6 +150,8 @@ export async function runBundler (argv: string[], overrideExit = true): Promise<
     ...config,
     autoBundleMempoolSize: 1
   }
+
+  await new DeterministicDeployer(wallet.provider as any).deterministicDeploy(BundlerHelper__factory.bytecode)
 
   const [execManager, eventsManager, reputationManager, mempoolManager] = initServer(execManagerConfig, entryPoint.signer)
   const methodHandler = new UserOpMethodHandler(

--- a/packages/bundler/test/DebugMethodHandler.test.ts
+++ b/packages/bundler/test/DebugMethodHandler.test.ts
@@ -1,0 +1,100 @@
+import { DebugMethodHandler } from '../src/DebugMethodHandler'
+import { ExecutionManager } from '../src/modules/ExecutionManager'
+import { BundlerReputationParams, ReputationManager } from '../src/modules/ReputationManager'
+import { BundlerConfig } from '../src/BundlerConfig'
+import { isGeth } from '../src/utils'
+import { parseEther } from 'ethers/lib/utils'
+import { MempoolManager } from '../src/modules/MempoolManager'
+import { ValidationManager } from '../src/modules/ValidationManager'
+import { BundleManager, SendBundleReturn } from '../src/modules/BundleManager'
+import { UserOpMethodHandler } from '../src/UserOpMethodHandler'
+import { ethers } from 'hardhat'
+import { EntryPoint, EntryPoint__factory, SimpleAccountFactory__factory } from '@account-abstraction/contracts'
+import { DeterministicDeployer, SimpleAccountAPI } from '@account-abstraction/sdk'
+import { BundlerHelper__factory } from '../src/types'
+import { Wallet } from 'ethers'
+import { resolveHexlify } from '@account-abstraction/utils'
+import { expect } from 'chai'
+
+const provider = ethers.provider
+const signer = provider.getSigner()
+describe('#DebugMethodHandler', () => {
+  let debugMethodHandler: DebugMethodHandler
+  let entryPoint: EntryPoint
+  let methodHandler: UserOpMethodHandler
+  let smartAccountAPI: SimpleAccountAPI
+  const accountSigner = Wallet.createRandom()
+
+  before(async () => {
+    entryPoint = await new EntryPoint__factory(signer).deploy()
+    DeterministicDeployer.init(provider)
+    const bundlerHelperAddress = await DeterministicDeployer.deploy(new BundlerHelper__factory(), 0, [])
+    const bundlerHelper = BundlerHelper__factory.connect(bundlerHelperAddress, provider)
+
+    console.log('ep=', entryPoint.address)
+    const config: BundlerConfig = {
+      beneficiary: await signer.getAddress(),
+      entryPoint: entryPoint.address,
+      bundlerHelper: bundlerHelperAddress,
+      gasFactor: '0.2',
+      minBalance: '0',
+      mnemonic: '',
+      network: '',
+      port: '3000',
+      unsafe: !await isGeth(provider as any),
+      autoBundleInterval: 0,
+      autoBundleMempoolSize: 0,
+      maxBundleGas: 5e6,
+      // minstake zero, since we don't fund deployer.
+      minStake: '0',
+      minUnstakeDelay: 0
+    }
+
+    const repMgr = new ReputationManager(BundlerReputationParams, parseEther(config.minStake), config.minUnstakeDelay)
+    const mempoolMgr = new MempoolManager(repMgr)
+    const validMgr = new ValidationManager(entryPoint, bundlerHelper, repMgr, config.unsafe)
+    const bundleMgr = new BundleManager(entryPoint, bundlerHelper, mempoolMgr, validMgr, repMgr, config.beneficiary, parseEther(config.minBalance), config.maxBundleGas)
+    const execManager = new ExecutionManager(repMgr, mempoolMgr, bundleMgr, validMgr)
+    methodHandler = new UserOpMethodHandler(
+      execManager,
+      provider,
+      signer,
+      config,
+      entryPoint
+    )
+
+    debugMethodHandler = new DebugMethodHandler(execManager, repMgr, mempoolMgr)
+
+    DeterministicDeployer.init(ethers.provider)
+    const accountDeployerAddress = await DeterministicDeployer.deploy(new SimpleAccountFactory__factory(), 0, [entryPoint.address])
+
+    smartAccountAPI = new SimpleAccountAPI({
+      provider,
+      entryPointAddress: entryPoint.address,
+      owner: accountSigner,
+      factoryAddress: accountDeployerAddress
+    })
+    const accountAddress = await smartAccountAPI.getAccountAddress()
+    await signer.sendTransaction({
+      to: accountAddress,
+      value: parseEther('1')
+    })
+  })
+
+  it('should return sendBundleNow hashes', async () => {
+    debugMethodHandler.setBundlingMode('manual')
+    const addr = await smartAccountAPI.getAccountAddress()
+    const op1 = await smartAccountAPI.createSignedUserOp({
+      target: addr,
+      data: '0x'
+    })
+    const userOpHash = await methodHandler.sendUserOperation(await resolveHexlify(op1), entryPoint.address)
+    const {
+      transactionHash,
+      userOpHashes
+    } = await debugMethodHandler.sendBundleNow() as SendBundleReturn
+    expect(userOpHashes).eql([userOpHash])
+    const txRcpt = await provider.getTransactionReceipt(transactionHash)
+    expect(txRcpt.to).to.eq(entryPoint.address)
+  })
+})

--- a/packages/bundler/test/UserOpMethodHandler.test.ts
+++ b/packages/bundler/test/UserOpMethodHandler.test.ts
@@ -19,7 +19,7 @@ import { postExecutionDump } from '@account-abstraction/utils/dist/src/postExecC
 import {
   SampleRecipient, TestRuleAccount, TestOpcodesAccount__factory, BundlerHelper__factory
 } from '../src/types'
-import { deepHexlify } from '@account-abstraction/utils'
+import { resolveHexlify } from '@account-abstraction/utils'
 import { UserOperationEventEvent } from '@account-abstraction/contracts/dist/types/EntryPoint'
 import { UserOperationReceipt } from '../src/RpcTypes'
 import { ExecutionManager } from '../src/modules/ExecutionManager'
@@ -28,12 +28,6 @@ import { MempoolManager } from '../src/modules/MempoolManager'
 import { ValidationManager } from '../src/modules/ValidationManager'
 import { BundleManager } from '../src/modules/BundleManager'
 import { isGeth, waitFor } from '../src/utils'
-
-// resolve all property and hexlify.
-// (UserOpMethodHandler receives data from the network, so we need to pack our generated values)
-async function resolveHexlify (a: any): Promise<any> {
-  return deepHexlify(await resolveProperties(a))
-}
 
 describe('UserOpMethodHandler', function () {
   const helloWorld = 'hello world'
@@ -82,7 +76,7 @@ describe('UserOpMethodHandler', function () {
     const repMgr = new ReputationManager(BundlerReputationParams, parseEther(config.minStake), config.minUnstakeDelay)
     const mempoolMgr = new MempoolManager(repMgr)
     const validMgr = new ValidationManager(entryPoint, bundlerHelper, repMgr, config.unsafe)
-    const bundleMgr = new BundleManager(entryPoint, mempoolMgr, validMgr, repMgr, config.beneficiary, parseEther(config.minBalance), config.maxBundleGas)
+    const bundleMgr = new BundleManager(entryPoint, bundlerHelper, mempoolMgr, validMgr, repMgr, config.beneficiary, parseEther(config.minBalance), config.maxBundleGas)
     const execManager = new ExecutionManager(repMgr, mempoolMgr, bundleMgr, validMgr)
     methodHandler = new UserOpMethodHandler(
       execManager,

--- a/packages/bundler/test/ValidateManager.test.ts
+++ b/packages/bundler/test/ValidateManager.test.ts
@@ -12,7 +12,8 @@ import {
   TestStorageAccount__factory,
   TestRulesAccount,
   TestRulesAccount__factory,
-  TestRulesAccountFactory__factory
+  TestRulesAccountFactory__factory,
+  BundlerHelper__factory
 } from '../src/types'
 import { ValidationManager } from '../src/modules/ValidationManager'
 import { ReputationManager } from '../src/modules/ReputationManager'
@@ -108,6 +109,7 @@ describe('#ValidationManager', () => {
     await paymaster.addStake(entryPoint.address, { value: parseEther('0.1') })
     opcodeFactory = await new TestOpcodesAccountFactory__factory(ethersSigner).deploy()
     storageFactory = await new TestStorageAccountFactory__factory(ethersSigner).deploy()
+    const bundlerHelper = await new BundlerHelper__factory(ethersSigner).deploy()
 
     const rulesFactory = await new TestRulesAccountFactory__factory(ethersSigner).deploy()
     storageAccount = TestRulesAccount__factory.connect(await rulesFactory.callStatic.create(''), provider)
@@ -121,7 +123,7 @@ describe('#ValidationManager', () => {
     },
     parseEther('0'), 0)
     const unsafe = !await isGeth(provider)
-    vm = new ValidationManager(entryPoint, reputationManager, unsafe)
+    vm = new ValidationManager(entryPoint, bundlerHelper, reputationManager, unsafe)
 
     if (!await isGeth(ethers.provider)) {
       console.log('WARNING: opcode banning tests can only run with geth')

--- a/packages/utils/src/ERC4337Utils.ts
+++ b/packages/utils/src/ERC4337Utils.ts
@@ -1,4 +1,4 @@
-import { defaultAbiCoder, hexConcat, hexlify, keccak256 } from 'ethers/lib/utils'
+import { defaultAbiCoder, hexConcat, hexlify, keccak256, resolveProperties } from 'ethers/lib/utils'
 import { UserOperationStruct } from '@account-abstraction/contracts'
 import { abi as entryPointAbi } from '@account-abstraction/contracts/artifacts/IEntryPoint.json'
 import { ethers } from 'ethers'
@@ -204,4 +204,10 @@ export function deepHexlify (obj: any): any {
       ...set,
       [key]: deepHexlify(obj[key])
     }), {})
+}
+
+// resolve all property and hexlify.
+// (UserOpMethodHandler receives data from the network, so we need to pack our generated values)
+export async function resolveHexlify (a: any): Promise<any> {
+  return deepHexlify(await resolveProperties(a))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9441,11 +9441,6 @@ solidity-coverage@^0.7.21:
     shelljs "^0.8.3"
     web3-utils "^1.3.0"
 
-solidity-string-utils@^0.0.8-0:
-  version "0.0.8-0"
-  resolved "https://registry.yarnpkg.com/solidity-string-utils/-/solidity-string-utils-0.0.8-0.tgz#17d9c4ec9297615e17de61e8bc587042727ee55d"
-  integrity sha512-AHyYRuySlm71vk/rzat5YkP/H+xr5g3a0THHljH2DFSilMnsbLNusSUXVfbU1A3IZrfnaocAx1FSM01/mtchzg==
-
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"


### PR DESCRIPTION
check code of all accessed code:
- must not be zero-sized (unless it is a precompile)
- are not modified before the 2nd validation (that is, fail the userOp before 2nd validation if a contract code was modified)

(reference bundler must do an RPC call to make this check, which is not too efficient.
for integrated bundler, it is expected that checking code-hashes is much lighter than repeating full validation)