### PR TITLE
Fix preGasCalculation related defects

### DIFF
--- a/packages/sdk/src/BaseAccountAPI.ts
+++ b/packages/sdk/src/BaseAccountAPI.ts
@@ -259,7 +259,8 @@ export abstract class BaseAccountAPI {
       callGasLimit,
       verificationGasLimit,
       maxFeePerGas,
-      maxPriorityFeePerGas
+      maxPriorityFeePerGas,
+      paymasterAndData: "0x"
     }
 
     let paymasterAndData: string | undefined
@@ -267,7 +268,7 @@ export abstract class BaseAccountAPI {
       // fill (partial) preVerificationGas (all except the cost of the generated paymasterAndData)
       const userOpForPm = {
         ...partialUserOp,
-        preVerificationGas: this.getPreVerificationGas(partialUserOp)
+        preVerificationGas: await this.getPreVerificationGas(partialUserOp)
       }
       paymasterAndData = await this.paymasterAPI.getPaymasterAndData(userOpForPm)
     }

--- a/packages/sdk/src/calcPreVerificationGas.ts
+++ b/packages/sdk/src/calcPreVerificationGas.ts
@@ -68,12 +68,13 @@ export function calcPreVerificationGas (userOp: Partial<NotPromise<UserOperation
   } as any
 
   const packed = arrayify(packUserOp(p, false))
+  const lengthInWord = (packed.length + 31) / 32;
   const callDataCost = packed.map(x => x === 0 ? ov.zeroByte : ov.nonZeroByte).reduce((sum, x) => sum + x)
   const ret = Math.round(
     callDataCost +
     ov.fixed / ov.bundleSize +
     ov.perUserOp +
-    ov.perUserOpWord * packed.length
+    ov.perUserOpWord * lengthInWord
   )
   return ret
 }


### PR DESCRIPTION
This pull request proposes three updates.

###  1. Incorrectly calculated preVerificationGas:

it should be calculated as :

```
  const lengthInWord = (packed.length + 31) / 32;
  const ret = Math.round(
    callDataCost +
    ov.fixed / ov.bundleSize +
    ov.perUserOp +
    ov.perUserOpWord * lengthInWord
  )
```

instead of 
```
  const ret = Math.round(
    callDataCost +
    ov.fixed / ov.bundleSize +
    ov.perUserOp +
    ov.perUserOpWord * packed.length
  )
```

### 2. fix preGasCalculation error reports due to undefined paymasterAndData

In BaseAccountAPI.createUnsignedUserOp, the partialUserOp does not initialize the "paymasterAndData", causing following error to happen :
```
TypeError: Cannot read properties of undefined (reading 'toHexString')
    at isHexable (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/bytes/src.ts/index.ts:58:21)
    at arrayify (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/bytes/src.ts/index.ts:115:9)
    at BytesCoder.DynamicBytesCoder.encode (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/abi/src.ts/coders/bytes.ts:17:25)
    at /Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/abi/src.ts/coders/array.ts:62:19
    at Array.forEach (<anonymous>)
    at pack (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/abi/src.ts/coders/array.ts:54:12)
    at TupleCoder.encode (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/abi/src.ts/coders/tuple.ts:54:20)
    at AbiCoder.encode (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@ethersproject/abi/src.ts/abi-coder.ts:111:15)
    at encode (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@account-abstraction/utils/src/ERC4337Utils.ts:23:26)
    at packUserOp (/Users/chubingnan/Dev/github/arc0035/Dapp-Learning/basic/34-aa/demowallet/node_modules/@account-abstraction/utils/src/ERC4337Utils.ts:100:10)
```
The way to fix it, is to set partialUserOp.paymasterAndData = "0x";

```
    const partialUserOp: any = {
      sender: this.getAccountAddress(),
      nonce: this.getNonce(),
      initCode,
      callData,
      callGasLimit,
      verificationGasLimit,
      maxFeePerGas,
      maxPriorityFeePerGas,
      paymasterAndData: "0x"// Add this!!other wise ethers.utils.defaultAbiCoder.encode will throw error since this field is undefined.
    }
```
### 3. Potentially unhandled exception during createUnsignedUserOp

In this piece of code, since we does not await the async "getPreverificationGas" call, the error is regarded as unhandled exception;it would not be caught by a try-catch block.

```
    let paymasterAndData: string | undefined
    if (this.paymasterAPI != null) {
      // fill (partial) preVerificationGas (all except the cost of the generated paymasterAndData)
      const userOpForPm = {
        ...partialUserOp,
        preVerificationGas: this.getPreVerificationGas(partialUserOp) //I prefer adding "await" to it
      }
      paymasterAndData = await this.paymasterAPI.getPaymasterAndData(userOpForPm)
    }
```

Another way to fix it is to resolveProperties of partialUserOp before it is passed into "this.getPreVerificationGas(partialUserOp)"

