### PR TITLE
Add executeBatch functionality in sdk

### DIFF
--- a/packages/sdk/src/BaseAccountAPI.ts
+++ b/packages/sdk/src/BaseAccountAPI.ts
@@ -31,11 +31,14 @@ export interface UserOpResult {
  * - getAccountInitCode - return the value to put into the "initCode" field, if the account is not yet deployed. should create the account instance using a factory contract.
  * - getNonce - return current account's nonce value
  * - encodeExecute - encode the call from entryPoint through our account to the target contract.
+ * - encodeExecuteBatch - encode the batched call from entryPoint through our account to the target contract.
  * - signUserOpHash - sign the hash of a UserOp.
  *
  * The user can use the following APIs:
  * - createUnsignedUserOp - given "target" and "calldata", fill userOp to perform that operation from the account.
  * - createSignedUserOp - helper to call the above createUnsignedUserOp, and then extract the userOpHash and sign it
+ * - createUnsignedUserOpBatch - given "dest" and "data", fill userOp to perform that operation from the account.
+ * - createSignedUserOpBatch - helper to call the above createUnsignedUserOpBatch, and then extract the userOpHash and sign it
  */
 export abstract class BaseAccountAPI {
   private senderAddress!: string

--- a/packages/sdk/src/SimpleAccountAPI.ts
+++ b/packages/sdk/src/SimpleAccountAPI.ts
@@ -99,6 +99,21 @@ export class SimpleAccountAPI extends BaseAccountAPI {
       ])
   }
 
+    /**
+   * encode batched method calls from entryPoint to our contract
+   * @param dest
+   * @param data
+   */
+  async encodeExecuteBatch (dest: string[], data: string[]): Promise<string> {
+    const accountContract = await this._getAccountContract()
+    return accountContract.interface.encodeFunctionData(
+      'executeBatch',
+      [
+        dest, 
+        data
+      ])
+  }
+
   async signUserOpHash (userOpHash: string): Promise<string> {
     return await this.owner.signMessage(arrayify(userOpHash))
   }

--- a/packages/sdk/src/TransactionDetailsForUserOp.ts
+++ b/packages/sdk/src/TransactionDetailsForUserOp.ts
@@ -8,3 +8,11 @@ export interface TransactionDetailsForUserOp {
   maxFeePerGas?: BigNumberish
   maxPriorityFeePerGas?: BigNumberish
 }
+
+export interface BatchTransactionDetailsForUserOp {
+  dest: string[]
+  data: string[]
+  gasLimit?: BigNumberish
+  maxFeePerGas?: BigNumberish
+  maxPriorityFeePerGas?: BigNumberish
+}


### PR DESCRIPTION
I added a createSignedUserOpBatch method and a series of helper methods to allow those using the sdk to create UserOps based on batched transactions .