### PR TITLE
Replace userOp if gas increase equals 10%

### DIFF
--- a/packages/bundler/src/modules/MempoolManager.ts
+++ b/packages/bundler/src/modules/MempoolManager.ts
@@ -80,7 +80,7 @@ export class MempoolManager {
     const oldGas = BigNumber.from(oldEntry.userOp.maxPriorityFeePerGas).toNumber()
     const newGas = BigNumber.from(entry.userOp.maxPriorityFeePerGas).toNumber()
     // the error is "invalid fields", even though it is detected only after validation
-    requireCond(newGas > oldGas * 1.1,
+    requireCond(newGas >= oldGas * 1.1,
       `Replacement UserOperation must have higher gas (old=${oldGas} new=${newGas}) `, ValidationErrors.InvalidFields)
   }
 


### PR DESCRIPTION
Fixes failing test case `test_bundle_replace_op[fee_bump_at_threshold]` from https://github.com/eth-infinitism/bundler-spec-tests/pull/4