### PR TITLE
Add RANDOM and PREVRANDAO for banned opcodes

### DIFF
--- a/packages/bundler/src/parseScannerResult.ts
+++ b/packages/bundler/src/parseScannerResult.ts
@@ -167,7 +167,7 @@ export function parseScannerResult (userOp: UserOperation, tracerResults: Bundle
 
   const entryPointAddress = entryPoint.address.toLowerCase()
 
-  const bannedOpCodes = new Set(['GASPRICE', 'GASLIMIT', 'DIFFICULTY', 'TIMESTAMP', 'BASEFEE', 'BLOCKHASH', 'NUMBER', 'SELFBALANCE', 'BALANCE', 'ORIGIN', 'GAS', 'CREATE', 'COINBASE', 'SELFDESTRUCT'])
+  const bannedOpCodes = new Set(['GASPRICE', 'GASLIMIT', 'DIFFICULTY', 'TIMESTAMP', 'BASEFEE', 'BLOCKHASH', 'NUMBER', 'SELFBALANCE', 'BALANCE', 'ORIGIN', 'GAS', 'CREATE', 'COINBASE', 'SELFDESTRUCT', 'RANDOM', 'PREVRANDAO'])
 
   // eslint-disable-next-line @typescript-eslint/no-base-to-string
   if (Object.values(tracerResults.numberLevels).length < 2) {


### PR DESCRIPTION
as of eip 4399, 0x44(DIFFICULTY) has been renamed to PREVRANDAO

https://eips.ethereum.org/EIPS/eip-4399

and geth uses 0x44 for DIFFICULTY, RANDOM, PREVRANDO.

`debug_traceCall` returns different data depending on the implementation since it is not a standard rpc. so it is wise to add all 3 of those opcodes to the ban list

https://github.com/ethereum/go-ethereum/blob/27e59827d804b0112c4213465ff3b902e25cb6d9/core/vm/opcodes.go#L96