### PR TITLE
Fix to await Promise function

### DIFF
--- a/packages/sdk/src/BaseAccountAPI.ts
+++ b/packages/sdk/src/BaseAccountAPI.ts
@@ -120,7 +120,7 @@ export abstract class BaseAccountAPI {
    * calculate the account address even before it is deployed
    */
   async getCounterFactualAddress (): Promise<string> {
-    const initCode = this.getAccountInitCode()
+    const initCode = await this.getAccountInitCode()
     // use entryPoint to query account address (factory can provide a helper method to do the same, but
     // this method attempts to be generic
     try {


### PR DESCRIPTION
`getAccountInitCode` is a Promise function so that we need to add `await`.