### PR TITLE
README update and wallet nonce fixes

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,7 +24,7 @@ const walletAPI = new SimpleAccountAPI({
     owner,
     factoryAddress
 })
-const op = await walletAPi.createSignedUserOp({
+const op = await walletAPI.createSignedUserOp({
   target: recipient.address,
   data: recipient.interface.encodeFunctionData('something', ['hello'])
 })
@@ -35,20 +35,20 @@ const op = await walletAPi.createSignedUserOp({
 A simplified mode that doesn't require a different wallet extension. 
 Instead, the current provider's account is used as wallet owner by calling its "Sign Message" operation.
 
-This can only work for wallets that use an EIP-191 ("Ethereum Signed Message") signatures (like our sample SimpleWallet)
+This can only work for wallets that use an EIP-191 ("Ethereum Signed Message") signature (like our sample SimpleWallet)
 Also, the UX is not great (the user is asked to sign a hash, and even the wallet address is not mentioned, only the signer)
 
 ```typescript
 import { wrapProvider } from '@account-abstraction/sdk'
 
 //use this account as wallet-owner (which will be used to sign the requests)
-const signer = provider.getSigner()
+const aaSigner = provider.getSigner()
 const config = {
   chainId: await provider.getNetwork().then(net => net.chainId),
   entryPointAddress,
   bundlerUrl: 'http://localhost:3000/rpc'
 } 
-const aaProvider = await wrapProvider(provider, config, aasigner)
+const aaProvider = await wrapProvider(provider, config, aaSigner)
 const walletAddress = await aaProvider.getSigner().getAddress()
 
 // send some eth to the wallet Address: wallet should have some balance to pay for its own creation, and for calling methods.

--- a/packages/sdk/src/BaseAccountAPI.ts
+++ b/packages/sdk/src/BaseAccountAPI.ts
@@ -253,7 +253,7 @@ export abstract class BaseAccountAPI {
 
     const partialUserOp: any = {
       sender: this.getAccountAddress(),
-      nonce: this.getNonce(),
+      nonce: info.nonce ?? this.getNonce(),
       initCode,
       callData,
       callGasLimit,

--- a/packages/sdk/src/SimpleAccountAPI.ts
+++ b/packages/sdk/src/SimpleAccountAPI.ts
@@ -18,7 +18,7 @@ import { BaseApiParams, BaseAccountAPI } from './BaseAccountAPI'
 export interface SimpleAccountApiParams extends BaseApiParams {
   owner: Signer
   factoryAddress?: string
-  index?: number
+  index?: BigNumberish
 
 }
 
@@ -32,7 +32,7 @@ export interface SimpleAccountApiParams extends BaseApiParams {
 export class SimpleAccountAPI extends BaseAccountAPI {
   factoryAddress?: string
   owner: Signer
-  index: number
+  index: BigNumberish
 
   /**
    * our account contract.
@@ -46,7 +46,7 @@ export class SimpleAccountAPI extends BaseAccountAPI {
     super(params)
     this.factoryAddress = params.factoryAddress
     this.owner = params.owner
-    this.index = params.index ?? 0
+    this.index = BigNumber.from(params.index ?? 0)
   }
 
   async _getAccountContract (): Promise<SimpleAccount> {

--- a/packages/sdk/src/TransactionDetailsForUserOp.ts
+++ b/packages/sdk/src/TransactionDetailsForUserOp.ts
@@ -7,4 +7,5 @@ export interface TransactionDetailsForUserOp {
   gasLimit?: BigNumberish
   maxFeePerGas?: BigNumberish
   maxPriorityFeePerGas?: BigNumberish
+  nonce?: BigNumberish
 }


### PR DESCRIPTION
* Fixed bugs in README examples
* Allow nonce to be a large number as it can be a salt of size uint256
* Allow nonce override in `createSignedUserOp` so multiple op txs can be sent to `handleOps` on the `EntryPoint` contract.