### PR TITLE
Only wait for receipt if user requests it

### DIFF
--- a/packages/sdk/src/ERC4337EthersProvider.ts
+++ b/packages/sdk/src/ERC4337EthersProvider.ts
@@ -92,7 +92,7 @@ export class ERC4337EthersProvider extends BaseProvider {
   async constructUserOpTransactionResponse (userOp1: UserOperationStruct): Promise<TransactionResponse> {
     const userOp = await resolveProperties(userOp1)
     const userOpHash = getUserOpHash(userOp, this.config.entryPointAddress, this.chainId)
-    const waitPromise = new Promise<TransactionReceipt>((resolve, reject) => {
+    const waitForUserOp = () => new Promise<TransactionReceipt>((resolve, reject) => {
       new UserOperationEventListener(
         resolve, reject, this.entryPoint, userOp.sender, userOpHash, userOp.nonce
       ).start()
@@ -107,7 +107,7 @@ export class ERC4337EthersProvider extends BaseProvider {
       data: hexValue(userOp.callData), // should extract the actual called method from this "execFromEntryPoint()" call
       chainId: this.chainId,
       wait: async (confirmations?: number): Promise<TransactionReceipt> => {
-        const transactionReceipt = await waitPromise
+        const transactionReceipt = await waitForUserOp();
         if (userOp.initCode.length !== 0) {
           // checking if the wallet has been deployed by the transaction; it must be if we are here
           await this.smartAccountAPI.checkAccountPhantom()


### PR DESCRIPTION
The current construction always starts waiting for the receipt immediately after the transaction is sent.

Some bundlers need more time than the `DEFAULT_TRANSACTION_TIMEOUT` and need to get receipt via `provider.waitForTransaction`.

Also fixes the fact that 2 listeners are started when user calls `.wait()` the usual way.