### PR TITLE
Handle exceptions within auto bundle thread

### DIFF
--- a/packages/bundler/src/modules/EventsManager.ts
+++ b/packages/bundler/src/modules/EventsManager.ts
@@ -34,8 +34,10 @@ export class EventsManager {
    * process all new events since last run
    */
   async handlePastEvents (): Promise<void> {
-    const fromBlock = this.lastBlock ?? Math.max(1, await this.entryPoint.provider.getBlockNumber() - 1000)
-    const events = await this.entryPoint.queryFilter({ address: this.entryPoint.address }, fromBlock)
+    if (this.lastBlock === undefined) {
+      this.lastBlock = Math.max(1, await this.entryPoint.provider.getBlockNumber() - 1000)
+    }
+    const events = await this.entryPoint.queryFilter({ address: this.entryPoint.address }, this.lastBlock)
     for (const ev of events) {
       this.handleEvent(ev)
     }

--- a/packages/bundler/src/modules/ExecutionManager.ts
+++ b/packages/bundler/src/modules/ExecutionManager.ts
@@ -69,7 +69,7 @@ export class ExecutionManager {
     this.autoInterval = autoBundleInterval
     if (autoBundleInterval !== 0) {
       this.autoBundleInterval = setInterval(() => {
-        void this.attemptBundle(true)
+        void this.attemptBundle(true).catch(e => console.error('auto-bundle failed', e))
       }, autoBundleInterval * 1000)
     }
     this.maxMempoolSize = maxMempoolSize


### PR DESCRIPTION
### Exception within _auto bundle thread_ can crash the bundler
[Line 72](https://github.com/eth-infinitism/bundler/blob/b096c8f8a1548d4f797b53167f966f96e60c2792/packages/bundler/src/modules/ExecutionManager.ts#L7), `attemptBundle`, interacts with multiple remote procedure calls (RPC), which can **fail**, e.g. RPC `timeout`. 
When an error occurs, the whole bundler server will actually **crash**.  


https://github.com/eth-infinitism/bundler/blob/b096c8f8a1548d4f797b53167f966f96e60c2792/packages/bundler/src/modules/ExecutionManager.ts#L66-L76

A more graceful way to handle this is to catch the exception and print out the exact error for further debugging.

### Reduce unnecessary RPCs
Line 37 calls `entryPoint.provider.getBlockNumber() ` for latest blocker number, but this latest blocker number isn't updated to `this.lastBlock`, which means, Line 37 will be called again and again until [line 56](https://github.com/eth-infinitism/bundler/blob/b096c8f8a1548d4f797b53167f966f96e60c2792/packages/bundler/src/modules/EventsManager.ts#L56) overrides it. We should update the `this.lastBlock` on the first try to avoid unnecessary RPC calls.
https://github.com/eth-infinitism/bundler/blob/b096c8f8a1548d4f797b53167f966f96e60c2792/packages/bundler/src/modules/EventsManager.ts#L36-L38

https://github.com/eth-infinitism/bundler/blob/b096c8f8a1548d4f797b53167f966f96e60c2792/packages/bundler/src/modules/EventsManager.ts#L44-L56
