### PR TITLE
Update getUserOpHash to comply with latest entrypoint.getUserOpHash logic

### DIFF
--- a/packages/utils/src/ERC4337Utils.ts
+++ b/packages/utils/src/ERC4337Utils.ts
@@ -1,4 +1,10 @@
-import { defaultAbiCoder, hexConcat, hexlify, keccak256, resolveProperties } from 'ethers/lib/utils'
+import {
+  defaultAbiCoder,
+  hexConcat,
+  hexlify,
+  keccak256,
+  resolveProperties
+} from 'ethers/lib/utils'
 import { UserOperationStruct } from '@account-abstraction/contracts'
 import { abi as entryPointAbi } from '@account-abstraction/contracts/artifacts/IEntryPoint.json'
 import { ethers } from 'ethers'
@@ -8,21 +14,37 @@ const debug = Debug('aa.utils')
 
 // UserOperation is the first parameter of validateUseOp
 const validateUserOpMethod = 'simulateValidation'
-const UserOpType = entryPointAbi.find(entry => entry.name === validateUserOpMethod)?.inputs[0]
+const UserOpType = entryPointAbi.find(
+  (entry) => entry.name === validateUserOpMethod
+)?.inputs[0]
 if (UserOpType == null) {
-  throw new Error(`unable to find method ${validateUserOpMethod} in EP ${entryPointAbi.filter(x => x.type === 'function').map(x => x.name).join(',')}`)
+  throw new Error(
+    `unable to find method ${validateUserOpMethod} in EP ${entryPointAbi
+      .filter((x) => x.type === 'function')
+      .map((x) => x.name)
+      .join(',')}`
+  )
 }
 
 export const AddressZero = ethers.constants.AddressZero
 
 // reverse "Deferrable" or "PromiseOrValue" fields
 export type NotPromise<T> = {
-  [P in keyof T]: Exclude<T[P], Promise<any>>
+  [P in keyof T]: Exclude<T[P], Promise<any>>;
 }
 
-function encode (typevalues: Array<{ type: string, val: any }>, forSignature: boolean): string {
-  const types = typevalues.map(typevalue => typevalue.type === 'bytes' && forSignature ? 'bytes32' : typevalue.type)
-  const values = typevalues.map((typevalue) => typevalue.type === 'bytes' && forSignature ? keccak256(typevalue.val) : typevalue.val)
+function encode (
+  typevalues: Array<{ type: string, val: any }>,
+  forSignature: boolean
+): string {
+  const types = typevalues.map((typevalue) =>
+    typevalue.type === 'bytes' && forSignature ? 'bytes32' : typevalue.type
+  )
+  const values = typevalues.map((typevalue) =>
+    typevalue.type === 'bytes' && forSignature
+      ? keccak256(typevalue.val)
+      : typevalue.val
+  )
   return defaultAbiCoder.encode(types, values)
 }
 
@@ -32,7 +54,21 @@ function encode (typevalues: Array<{ type: string, val: any }>, forSignature: bo
  * @param forSignature "true" if the hash is needed to calculate the getUserOpHash()
  *  "false" to pack entire UserOp, for calculating the calldata cost of putting it on-chain.
  */
-export function packUserOp (op: NotPromise<UserOperationStruct>, forSignature = true): string {
+export function packUserOp (
+  op: NotPromise<UserOperationStruct>,
+  forSignature = true
+): string {
+  const initCodeHash = keccak256(op.initCode)
+  const callDataHash = keccak256(op.callData)
+  const paymasterAndDataHash = keccak256(op.paymasterAndData)
+
+  const userOp = {
+    ...op,
+    initCode: initCodeHash,
+    callData: callDataHash,
+    paymasterAndData: paymasterAndDataHash
+  }
+
   if (forSignature) {
     // lighter signature scheme (must match UserOperation#pack): do encode a zero-length signature, but strip afterwards the appended zero-length value
     const userOpType = {
@@ -46,11 +82,11 @@ export function packUserOp (op: NotPromise<UserOperationStruct>, forSignature = 
           name: 'nonce'
         },
         {
-          type: 'bytes',
+          type: 'bytes32',
           name: 'initCode'
         },
         {
-          type: 'bytes',
+          type: 'bytes32',
           name: 'callData'
         },
         {
@@ -74,7 +110,7 @@ export function packUserOp (op: NotPromise<UserOperationStruct>, forSignature = 
           name: 'maxPriorityFeePerGas'
         },
         {
-          type: 'bytes',
+          type: 'bytes32',
           name: 'paymasterAndData'
         },
         {
@@ -87,19 +123,26 @@ export function packUserOp (op: NotPromise<UserOperationStruct>, forSignature = 
     }
     // console.log('hard-coded userOpType', userOpType)
     // console.log('from ABI userOpType', UserOpType)
-    let encoded = defaultAbiCoder.encode([userOpType as any], [{
-      ...op,
-      signature: '0x'
-    }])
+    let encoded = defaultAbiCoder.encode(
+      [userOpType as any],
+      [
+        {
+          ...userOp,
+          signature: '0x'
+        }
+      ]
+    )
     // remove leading word (total length) and trailing word (zero-length signature)
     encoded = '0x' + encoded.slice(66, encoded.length - 64)
     return encoded
   }
 
-  const typevalues = (UserOpType as any).components.map((c: { name: keyof typeof op, type: string }) => ({
-    type: c.type,
-    val: op[c.name]
-  }))
+  const typevalues = (UserOpType as any).components.map(
+    (c: { name: keyof typeof userOp, type: string }) => ({
+      type: c.type,
+      val: userOp[c.name]
+    })
+  )
   return encode(typevalues, forSignature)
 }
 
@@ -112,16 +155,24 @@ export function packUserOp (op: NotPromise<UserOperationStruct>, forSignature = 
  * @param entryPoint
  * @param chainId
  */
-export function getUserOpHash (op: NotPromise<UserOperationStruct>, entryPoint: string, chainId: number): string {
+export function getUserOpHash (
+  op: NotPromise<UserOperationStruct>,
+  entryPoint: string,
+  chainId: number
+): string {
   const userOpHash = keccak256(packUserOp(op, true))
   const enc = defaultAbiCoder.encode(
     ['bytes32', 'address', 'uint256'],
-    [userOpHash, entryPoint, chainId])
+    [userOpHash, entryPoint, chainId]
+  )
   return keccak256(enc)
 }
 
 const ErrorSig = keccak256(Buffer.from('Error(string)')).slice(0, 10) // 0x08c379a0
-const FailedOpSig = keccak256(Buffer.from('FailedOp(uint256,string)')).slice(0, 10) // 0x220266b6
+const FailedOpSig = keccak256(Buffer.from('FailedOp(uint256,string)')).slice(
+  0,
+  10
+) // 0x220266b6
 
 interface DecodedError {
   message: string
@@ -134,10 +185,16 @@ interface DecodedError {
 export function decodeErrorReason (error: string): DecodedError | undefined {
   debug('decoding', error)
   if (error.startsWith(ErrorSig)) {
-    const [message] = defaultAbiCoder.decode(['string'], '0x' + error.substring(10))
+    const [message] = defaultAbiCoder.decode(
+      ['string'],
+      '0x' + error.substring(10)
+    )
     return { message }
   } else if (error.startsWith(FailedOpSig)) {
-    let [opIndex, message] = defaultAbiCoder.decode(['uint256', 'string'], '0x' + error.substring(10))
+    let [opIndex, message] = defaultAbiCoder.decode(
+      ['uint256', 'string'],
+      '0x' + error.substring(10)
+    )
     message = `FailedOp: ${message as string}`
     return {
       message,
@@ -162,13 +219,19 @@ export function rethrowError (e: any): any {
     parent = error
     error = error.data
   }
-  const decoded = typeof error === 'string' && error.length > 2 ? decodeErrorReason(error) : undefined
+  const decoded =
+    typeof error === 'string' && error.length > 2
+      ? decodeErrorReason(error)
+      : undefined
   if (decoded != null) {
     e.message = decoded.message
 
     if (decoded.opIndex != null) {
       // helper for chai: convert our FailedOp error into "Error(msg)"
-      const errorWithMsg = hexConcat([ErrorSig, defaultAbiCoder.encode(['string'], [decoded.message])])
+      const errorWithMsg = hexConcat([
+        ErrorSig,
+        defaultAbiCoder.encode(['string'], [decoded.message])
+      ])
       // modify in-place the error object:
       parent.data = errorWithMsg
     }
@@ -190,13 +253,15 @@ export function deepHexlify (obj: any): any {
     return hexlify(obj).replace(/^0x0/, '0x')
   }
   if (Array.isArray(obj)) {
-    return obj.map(member => deepHexlify(member))
+    return obj.map((member) => deepHexlify(member))
   }
-  return Object.keys(obj)
-    .reduce((set, key) => ({
+  return Object.keys(obj).reduce(
+    (set, key) => ({
       ...set,
       [key]: deepHexlify(obj[key])
-    }), {})
+    }),
+    {}
+  )
 }
 
 // resolve all property and hexlify.


### PR DESCRIPTION
The goal of this PR is to make the off-chain `getUserOpHash` method logic parity with the on-chain[ solidity equivalent](https://github.com/eth-infinitism/account-abstraction/blob/9b5f2e4bb30a81aa30761749d9e2e43fee64c768/contracts/interfaces/UserOperation.sol#L63-L86):
```
    function pack(UserOperation calldata userOp) internal pure returns (bytes memory ret) {
        address sender = getSender(userOp);
        uint256 nonce = userOp.nonce;
        bytes32 hashInitCode = calldataKeccak(userOp.initCode);
        bytes32 hashCallData = calldataKeccak(userOp.callData);
        uint256 callGasLimit = userOp.callGasLimit;
        uint256 verificationGasLimit = userOp.verificationGasLimit;
        uint256 preVerificationGas = userOp.preVerificationGas;
        uint256 maxFeePerGas = userOp.maxFeePerGas;
        uint256 maxPriorityFeePerGas = userOp.maxPriorityFeePerGas;
        bytes32 hashPaymasterAndData = calldataKeccak(userOp.paymasterAndData);


        return abi.encode(
            sender, nonce,
            hashInitCode, hashCallData,
            callGasLimit, verificationGasLimit, preVerificationGas,
            maxFeePerGas, maxPriorityFeePerGas,
            hashPaymasterAndData
        );
    }


    function hash(UserOperation calldata userOp) internal pure returns (bytes32) {
        return keccak256(pack(userOp));
    }
```

This PR is a WIP as there is still an issue producing the correct user op hashes via the js implementation. It would be good to get a second set of eyes on it.