### PR TITLE
Fixed error in encodeExecute for getAccount if account did not deploy…

### DIFF
--- a/packages/sdk/src/SimpleAccountAPI.ts
+++ b/packages/sdk/src/SimpleAccountAPI.ts
@@ -89,8 +89,8 @@ export class SimpleAccountAPI extends BaseAccountAPI {
    * @param data
    */
   async encodeExecute (target: string, value: BigNumberish, data: string): Promise<string> {
-    const accountContract = await this._getAccountContract()
-    return accountContract.interface.encodeFunctionData(
+    const accountInterface = SimpleAccount__factory.createInterface()
+    return accountInterface.encodeFunctionData(
       'execute',
       [
         target,


### PR DESCRIPTION
…ed yet

Changed encodeExecute fn using account interface to encode instead of using connected account contract, to prevent if account contract did not be deployed yet, as ```checkAccountPhantom()``` is used in ```getNonce()```