### PR TITLE
Fix EntryPoint deployment

### DIFF
--- a/packages/bundler/src/runner/runop.ts
+++ b/packages/bundler/src/runner/runop.ts
@@ -176,10 +176,11 @@ async function main (): Promise<void> {
   const requiredBalance = gasPrice.mul(2e6)
   if (bal.lt(requiredBalance.div(2))) {
     console.log('funding account to', requiredBalance.toString())
-    await signer.sendTransaction({
-      to: addr,
-      value: requiredBalance.sub(bal)
-    }).then(async tx => await tx.wait())
+    const fundTx = await signer.sendTransaction({ to: addr, value: requiredBalance.sub(bal) })
+    const receipt = await provider.waitForTransaction(fundTx.hash, 1, 20000)
+    if (receipt.status !== 1) {
+      throw new Error(`Funding TX did not succeed!\n Receipt: ${JSON.stringify(receipt)} `)
+    }
   } else {
     console.log('not funding account. balance is enough')
   }

--- a/packages/sdk/src/DeterministicDeployer.ts
+++ b/packages/sdk/src/DeterministicDeployer.ts
@@ -40,7 +40,7 @@ export class DeterministicDeployer {
   static deploymentSignerAddress = '0x3fab184622dc19b6109349b94811493bf2a45362'
   static deploymentGasPrice = 100e9
   static deploymentGasLimit = 100000
-  static txWaitTimeout =  150000
+  static txWaitTimeout = 150000
 
   constructor (
     readonly provider: JsonRpcProvider,

--- a/packages/sdk/src/DeterministicDeployer.ts
+++ b/packages/sdk/src/DeterministicDeployer.ts
@@ -70,7 +70,7 @@ export class DeterministicDeployer {
       })
       const receipt = await this.provider.waitForTransaction(txResponse.hash, 1, DeterministicDeployer.txWaitTimeout)
       if (receipt.status !== 1) {
-        throw new Error(`Funding TX did not succeed!\n Receipt: ${JSON.stringify(receipt)} `)
+        throw new Error(`Funding TX failed!\n Receipt: ${JSON.stringify(receipt)} `)
       }
     }
     const txHash = await this.provider.send('eth_sendRawTransaction', [DeterministicDeployer.deploymentTransaction])
@@ -125,8 +125,12 @@ export class DeterministicDeployer {
     const addr = DeterministicDeployer.getDeterministicDeployAddress(ctrCode, salt, params)
     if (!await this.isContractDeployed(addr)) {
       const signer = this.signer ?? this.provider.getSigner()
-      await signer.sendTransaction(
+      const txResponse = await signer.sendTransaction(
         await this.getDeployTransaction(ctrCode, salt, params))
+      const receipt = await this.provider.waitForTransaction(txResponse.hash, 1, DeterministicDeployer.txWaitTimeout)
+      if (receipt.status !== 1) {
+        throw new Error(`deterministicDeploy failed!\n Receipt: ${JSON.stringify(receipt)} `)
+      }
     }
     return addr
   }


### PR DESCRIPTION
## Issue
Deployment of EntryPoint contract through : `yarn hardhat-deploy --network localhost` usually fails due to `DeterministicDeployer` not waiting for a transaction to be confirmed before sending the next one. 

Deploying the EntryPoint contract involves 3 transactions in a row:
1. Funding the deployer's account.
2. Deploying the factory contract.
3. Sending a transaction to factory contract to deploy the EntryPoint contract.

Because the `DeterministicDeployer` does not wait for each step to be completed successfully before moving to the next step, the deployment script usually throws an error. The deployment is successful only after several runs (when the factory contract is already deployed in a previous run, which means that no error can be thrown anymore).

## Proposed Solution
Wait for confirmation receipt after each step before moving to the next step in the deployment process. This allows sufficient time for the state of the blockchain to update before the deployer goes on with the next step, and the EntryPoint contract can be deployed successfully in the first run of the script.