### PR TITLE
 We need to change recipient contract state in one call with erc-4337 

### DIFF
--- a/packages/utils/contracts/test/SampleRecipient.sol
+++ b/packages/utils/contracts/test/SampleRecipient.sol
@@ -9,9 +9,12 @@ contract SampleRecipient {
 
     SimpleAccount wallet;
 
+     string public lastMessage;
+
     event Sender(address txOrigin, address msgSender, string message);
 
     function something(string memory message) public {
+        lastMessage = message;
         emit Sender(tx.origin, msg.sender, message);
     }
 


### PR DESCRIPTION
Added lastMessage variable to SimpleRecipient.sol and setting it when calling something method wich leads to failing tests.
This case shows, that the recipient contract's variable can not be changed if creating account and executing UserOperation is packed in one transaction.
How to reproduce:
- add storage variable to recipent contract
- run  hardhat test test/UserOpMethodHandler.test.ts
Test fails with UserOperation not succeeded
@drortirosh 