### PR TITLE
use hardhat's provider's signer

### DIFF
--- a/packages/bundler/src/BundlerServer.ts
+++ b/packages/bundler/src/BundlerServer.ts
@@ -2,7 +2,7 @@ import bodyParser from 'body-parser'
 import cors from 'cors'
 import express, { Express, Response, Request } from 'express'
 import { Provider } from '@ethersproject/providers'
-import { Wallet, utils } from 'ethers'
+import { Signer, utils } from 'ethers'
 import { parseEther } from 'ethers/lib/utils'
 
 import { AddressZero, deepHexlify, erc4337RuntimeVersion } from '@account-abstraction/utils'
@@ -26,7 +26,7 @@ export class BundlerServer {
     readonly debugHandler: DebugMethodHandler,
     readonly config: BundlerConfig,
     readonly provider: Provider,
-    readonly wallet: Wallet
+    readonly wallet: Signer
   ) {
     this.app = express()
     this.app.use(cors())
@@ -77,8 +77,9 @@ export class BundlerServer {
     if (err?.errorName !== 'FailedOp') {
       this.fatal(`Invalid entryPoint contract at ${this.config.entryPoint}. wrong version?`)
     }
-    const bal = await this.provider.getBalance(this.wallet.address)
-    console.log('signer', this.wallet.address, 'balance', utils.formatEther(bal))
+    const signerAddress = await this.wallet.getAddress()
+    const bal = await this.provider.getBalance(signerAddress)
+    console.log('signer', signerAddress, 'balance', utils.formatEther(bal))
     if (bal.eq(0)) {
       this.fatal('cannot run with zero balance')
     } else if (bal.lt(parseEther(this.config.minBalance))) {

--- a/packages/bundler/src/Config.ts
+++ b/packages/bundler/src/Config.ts
@@ -2,7 +2,7 @@ import ow from 'ow'
 import fs from 'fs'
 
 import { BundlerConfig, bundlerConfigDefault, BundlerConfigShape } from './BundlerConfig'
-import { Wallet } from 'ethers'
+import { Wallet, Signer } from 'ethers'
 import { BaseProvider, JsonRpcProvider } from '@ethersproject/providers'
 
 function getCommandLineParams (programOpts: any): Partial<BundlerConfig> {
@@ -33,7 +33,7 @@ export function getNetworkProvider (url: string): JsonRpcProvider {
   return new JsonRpcProvider(url)
 }
 
-export async function resolveConfiguration (programOpts: any): Promise<{ config: BundlerConfig, provider: BaseProvider, wallet: Wallet }> {
+export async function resolveConfiguration (programOpts: any): Promise<{ config: BundlerConfig, provider: BaseProvider, wallet: Signer }> {
   const commandLineParams = getCommandLineParams(programOpts)
   let fileConfig: Partial<BundlerConfig> = {}
   const configFileName = programOpts.config
@@ -43,10 +43,12 @@ export async function resolveConfiguration (programOpts: any): Promise<{ config:
   const config = mergeConfigs(bundlerConfigDefault, fileConfig, commandLineParams)
   console.log('Merged configuration:', JSON.stringify(config))
 
-  const provider: BaseProvider = config.network === 'hardhat'
-    // eslint-disable-next-line
-    ? require('hardhat').ethers.provider
-    : getNetworkProvider(config.network)
+  if (config.network === 'hardhat') {
+    const provider: JsonRpcProvider = require('hardhat').ethers.provider
+    return { config, provider, wallet: provider.getSigner() }
+  }
+  
+  const provider: BaseProvider = getNetworkProvider(config.network)
 
   let mnemonic: string
   let wallet: Wallet

--- a/packages/bundler/src/Config.ts
+++ b/packages/bundler/src/Config.ts
@@ -44,12 +44,12 @@ export async function resolveConfiguration (programOpts: any): Promise<{ config:
   console.log('Merged configuration:', JSON.stringify(config))
 
   if (config.network === 'hardhat') {
+    // eslint-disable-next-line
     const provider: JsonRpcProvider = require('hardhat').ethers.provider
     return { config, provider, wallet: provider.getSigner() }
   }
-  
-  const provider: BaseProvider = getNetworkProvider(config.network)
 
+  const provider: BaseProvider = getNetworkProvider(config.network)
   let mnemonic: string
   let wallet: Wallet
   try {

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 
 import { Command } from 'commander'
 import { erc4337RuntimeVersion } from '@account-abstraction/utils'
-import { ethers, Wallet } from 'ethers'
+import { ethers, Wallet, Signer } from 'ethers'
 
 import { BundlerServer } from './BundlerServer'
 import { UserOpMethodHandler } from './UserOpMethodHandler'
@@ -29,7 +29,7 @@ const CONFIG_FILE_NAME = 'workdir/bundler.config.json'
 export let showStackTraces = false
 
 export async function connectContracts (
-  wallet: Wallet,
+  wallet: Signer,
   entryPointAddress: string): Promise<{ entryPoint: EntryPoint }> {
   const entryPoint = EntryPoint__factory.connect(entryPointAddress, wallet)
   return {


### PR DESCRIPTION
# Issue
When configuring the Bundler to use the `hardhat` configuration, transaction signing is still performed by the Bundler's wallet.

# Suggestion
Since Hardhat `ethers` providers implement their own signing functionality (as configured in `hardhat.config.ts`), this could be used for signing the Bundler's transactions.

This would enable hardhat plugins, who offer `ethers.provider` with signing functionality, to integrate with the Bundler simply through configuration changes.

# Proposed solution
Since `Wallet` derives from `Signer`, we modified `resolveConfiguration` (in `Config.ts`) to instead return a `Signer`.

When `hardhat` configuration is selected, the signer resolves to `ethers.provider.getSigner()`

The wallet is then used as expected in the rest of the code.