### PR TITLE
AA-168 tracer support handle ops

### DIFF
--- a/packages/bundler/contracts/tests/TracerTest.sol
+++ b/packages/bundler/contracts/tests/TracerTest.sol
@@ -65,5 +65,14 @@ contract TracerTest {
         }
         this.revertWithMessage{gas : gas}();
     }
+
+    event BeforeExecution();
+
+    function testStopTracing() public {
+        this.callTimeStamp();
+        this.callTimeStamp();
+        emit BeforeExecution();
+        this.callTimeStamp();
+    }
 }
 

--- a/packages/bundler/src/BundlerCollectorTracer.ts
+++ b/packages/bundler/src/BundlerCollectorTracer.ts
@@ -93,13 +93,7 @@ interface BundlerCollectorTracer extends LogTracer, BundlerCollectorReturn {
 export function bundlerCollectorTracer (): BundlerCollectorTracer {
   return {
     topLevelCalls: [],
-    currentLevel: {
-      topLevelMethodSig: 'nomethod',
-      topLevelTargetAddress: 'noaddress',
-      opcodes: {},
-      access: {},
-      contractSize: {}
-    },
+    currentLevel: null as any,
     keccak: [],
     calls: [],
     logs: [],
@@ -168,7 +162,7 @@ export function bundlerCollectorTracer (): BundlerCollectorTracer {
       }
 
       if (log.getDepth() === 1) {
-        if (opcode === 'CALL') {
+        if (opcode === 'CALL' || opcode == 'STATICCALL') {
           // stack.peek(0) - gas
           const addr = toAddress(log.stack.peek(1).toString(16))
           const topLevelTargetAddress = toHex(addr)

--- a/packages/bundler/src/BundlerCollectorTracer.ts
+++ b/packages/bundler/src/BundlerCollectorTracer.ts
@@ -162,7 +162,7 @@ export function bundlerCollectorTracer (): BundlerCollectorTracer {
       }
 
       if (log.getDepth() === 1) {
-        if (opcode === 'CALL' || opcode == 'STATICCALL') {
+        if (opcode === 'CALL' || opcode === 'STATICCALL') {
           // stack.peek(0) - gas
           const addr = toAddress(log.stack.peek(1).toString(16))
           const topLevelTargetAddress = toHex(addr)

--- a/packages/bundler/src/parseScannerResult.ts
+++ b/packages/bundler/src/parseScannerResult.ts
@@ -4,7 +4,7 @@ import {
   IPaymaster__factory, SenderCreator__factory
 } from '@account-abstraction/contracts'
 import { hexZeroPad, Interface, keccak256 } from 'ethers/lib/utils'
-import { BundlerCollectorReturn, TopLevelCallInfo } from './BundlerCollectorTracer'
+import { BundlerCollectorReturn } from './BundlerCollectorTracer'
 import { mapOf, requireCond } from './utils'
 import { inspect } from 'util'
 
@@ -200,23 +200,22 @@ export function parseScannerResult (userOp: UserOperation, tracerResults: Bundle
     paymaster: validationResult.paymasterInfo
   }
 
-  //method-signature for entity calls.
-  const topLevelMethodSigs: {[key:string]: string} = {
-    'factory': '0x570e1a36', //createSender
-    'account': '0x3a871cdd', //validateUserOp'
-    'paymaster': '0xf465c77e' //validatePaymasterUserOp
+  // method-signature for entity calls.
+  const topLevelMethodSigs: {[key: string]: string} = {
+    factory: '0x570e1a36', // createSender
+    account: '0x3a871cdd', // validateUserOp'
+    paymaster: '0xf465c77e' // validatePaymasterUserOp
   }
-
 
   const entitySlots: { [addr: string]: Set<string> } = parseEntitySlots(stakeInfoEntities, tracerResults.keccak)
 
   Object.entries(stakeInfoEntities).forEach(([entityTitle, entStakes]) => {
     const entityAddr = entStakes?.addr ?? ''
-    const currentNumLevel = tracerResults.topLevelCalls.find(info=>info.topLevelMethodSig === topLevelMethodSigs[entityTitle])
-    if ( currentNumLevel==null ) {
-      if ( entityTitle==='account') {
-        //should never happen... only factory, paymaster are optional.
-        throw new Error( 'missing trace into validateUserOp')
+    const currentNumLevel = tracerResults.topLevelCalls.find(info => info.topLevelMethodSig === topLevelMethodSigs[entityTitle])
+    if (currentNumLevel == null) {
+      if (entityTitle === 'account') {
+        // should never happen... only factory, paymaster are optional.
+        throw new Error('missing trace into validateUserOp')
       }
       return
     }

--- a/packages/bundler/src/parseScannerResult.ts
+++ b/packages/bundler/src/parseScannerResult.ts
@@ -339,7 +339,8 @@ export function parseScannerResult (userOp: UserOperation, tracerResults: Bundle
       // TODO: check real minimum stake values
     }
 
-    requireCond(Object.keys(currentNumLevel.contractSize).find(addr => currentNumLevel.contractSize[addr] <= 2) == null,
+    // the only contract we allow to access before its deployment is the "sender" itself, which gets created.
+    requireCond(Object.keys(currentNumLevel.contractSize).find(addr => addr !== sender && currentNumLevel.contractSize[addr] <= 2) == null,
       `${entityTitle} accesses un-deployed contract ${JSON.stringify(currentNumLevel.contractSize)}`, ValidationErrors.OpcodeValidation)
   })
 

--- a/packages/bundler/test/tracer.test.ts
+++ b/packages/bundler/test/tracer.test.ts
@@ -25,12 +25,12 @@ describe('#bundlerCollectorTracer', () => {
     const ret = await traceExecSelf(tester.interface.encodeFunctionData('callTimeStamp'), false, true)
     const execEvent = tester.interface.decodeEventLog('ExecSelfResult', ret.logs[0].data, ret.logs[0].topics)
     expect(execEvent.success).to.equal(true)
-    expect(ret.topLevelCalls[0].opcodes.TIMESTAMP).to.equal(1)
+    expect(ret.callsFromEntryPoint[0].opcodes.TIMESTAMP).to.equal(1)
   })
 
   it('should not count opcodes on depth==1', async () => {
     const ret = await traceCall(tester.interface.encodeFunctionData('callTimeStamp'))
-    expect(ret.topLevelCalls[0]?.opcodes.TIMESTAMP).to.be.undefined
+    expect(ret.callsFromEntryPoint[0]?.opcodes.TIMESTAMP).to.be.undefined
     // verify no error..
     expect(ret.debug.toString()).to.not.match(/REVERT/)
   })
@@ -79,7 +79,7 @@ describe('#bundlerCollectorTracer', () => {
 
   it('should report direct use of GAS opcode', async () => {
     const ret = await traceExecSelf(tester.interface.encodeFunctionData('testCallGas'), false)
-    expect(ret.topLevelCalls['0'].opcodes.GAS).to.eq(1)
+    expect(ret.callsFromEntryPoint['0'].opcodes.GAS).to.eq(1)
   })
 
   it('should ignore gas used as part of "call"', async () => {
@@ -87,13 +87,13 @@ describe('#bundlerCollectorTracer', () => {
     const doNothing = tester.interface.encodeFunctionData('doNothing')
     const callDoNothing = tester.interface.encodeFunctionData('execSelf', [doNothing, false])
     const ret = await traceExecSelf(callDoNothing, false)
-    expect(ret.topLevelCalls['0'].opcodes.GAS).to.be.undefined
+    expect(ret.callsFromEntryPoint['0'].opcodes.GAS).to.be.undefined
   })
 
   it('should collect traces only until BeginExecution event', async () => {
     // the method calls "callTimeStamp" 3 times, but should stop tracing after 2 times..
     const callStopTracing = tester.interface.encodeFunctionData('testStopTracing')
     const ret = await traceCall(callStopTracing)
-    expect(ret.topLevelCalls.length).to.eql(2)
+    expect(ret.callsFromEntryPoint.length).to.eql(2)
   })
 })

--- a/packages/bundler/test/tracer.test.ts
+++ b/packages/bundler/test/tracer.test.ts
@@ -25,12 +25,13 @@ describe('#bundlerCollectorTracer', () => {
     const ret = await traceExecSelf(tester.interface.encodeFunctionData('callTimeStamp'), false, true)
     const execEvent = tester.interface.decodeEventLog('ExecSelfResult', ret.logs[0].data, ret.logs[0].topics)
     expect(execEvent.success).to.equal(true)
-    expect(ret.numberLevels[0].opcodes.TIMESTAMP).to.equal(1)
+    expect(ret.topLevelCalls[0].opcodes.TIMESTAMP).to.equal(1)
   })
 
   it('should not count opcodes on depth==1', async () => {
     const ret = await traceCall(tester.interface.encodeFunctionData('callTimeStamp'))
-    expect(ret.numberLevels[0].opcodes.TIMESTAMP).to.be.undefined
+    console.log('ret=', JSON.stringify(ret,null,2))
+    expect(ret.topLevelCalls[0]?.opcodes.TIMESTAMP).to.be.undefined
     // verify no error..
     expect(ret.debug.toString()).to.not.match(/REVERT/)
   })
@@ -79,7 +80,7 @@ describe('#bundlerCollectorTracer', () => {
 
   it('should report direct use of GAS opcode', async () => {
     const ret = await traceExecSelf(tester.interface.encodeFunctionData('testCallGas'), false)
-    expect(ret.numberLevels['0'].opcodes.GAS).to.eq(1)
+    expect(ret.topLevelCalls['0'].opcodes.GAS).to.eq(1)
   })
 
   it('should ignore gas used as part of "call"', async () => {
@@ -87,6 +88,6 @@ describe('#bundlerCollectorTracer', () => {
     const doNothing = tester.interface.encodeFunctionData('doNothing')
     const callDoNothing = tester.interface.encodeFunctionData('execSelf', [doNothing, false])
     const ret = await traceExecSelf(callDoNothing, false)
-    expect(ret.numberLevels['0'].opcodes.GAS).to.be.undefined
+    expect(ret.topLevelCalls['0'].opcodes.GAS).to.be.undefined
   })
 })

--- a/packages/bundler/test/tracer.test.ts
+++ b/packages/bundler/test/tracer.test.ts
@@ -30,7 +30,6 @@ describe('#bundlerCollectorTracer', () => {
 
   it('should not count opcodes on depth==1', async () => {
     const ret = await traceCall(tester.interface.encodeFunctionData('callTimeStamp'))
-    console.log('ret=', JSON.stringify(ret,null,2))
     expect(ret.topLevelCalls[0]?.opcodes.TIMESTAMP).to.be.undefined
     // verify no error..
     expect(ret.debug.toString()).to.not.match(/REVERT/)
@@ -89,5 +88,13 @@ describe('#bundlerCollectorTracer', () => {
     const callDoNothing = tester.interface.encodeFunctionData('execSelf', [doNothing, false])
     const ret = await traceExecSelf(callDoNothing, false)
     expect(ret.topLevelCalls['0'].opcodes.GAS).to.be.undefined
+  })
+
+  it('should collect traces only until BeginExecution event', async () => {
+    // the method calls "callTimeStamp" 3 times, but should stop tracing after 2 times..
+    const callStopTracing = tester.interface.encodeFunctionData('testStopTracing')
+    const ret = await traceCall(callStopTracing)
+    console.log(ret.debug)
+    expect(ret.topLevelCalls.length).to.eql(2)
   })
 })

--- a/packages/bundler/test/tracer.test.ts
+++ b/packages/bundler/test/tracer.test.ts
@@ -94,7 +94,6 @@ describe('#bundlerCollectorTracer', () => {
     // the method calls "callTimeStamp" 3 times, but should stop tracing after 2 times..
     const callStopTracing = tester.interface.encodeFunctionData('testStopTracing')
     const ret = await traceCall(callStopTracing)
-    console.log(ret.debug)
     expect(ret.topLevelCalls.length).to.eql(2)
   })
 })


### PR DESCRIPTION
remove dependency on NUMBER opcode.
instead, use top-level calls to createSender, validateUserOp, validatePaymasterUserOp
(this, in turn, allows tracing multi-userop transactions, namely handleOps...)