### PR TITLE
support jsonrpc batching

### DIFF
--- a/packages/bundler/src/BundlerServer.ts
+++ b/packages/bundler/src/BundlerServer.ts
@@ -97,22 +97,45 @@ export class BundlerServer {
   }
 
   async rpc (req: Request, res: Response): Promise<void> {
+    let resContent: any
+    if (Array.isArray(req.body)) {
+      resContent = []
+      for (const reqItem of req.body) {
+        resContent.push(await this.handleRpc(reqItem))
+      }
+    } else {
+      resContent = await this.handleRpc(req.body)
+    }
+
+    try {
+      res.send(resContent)
+    } catch (err: any) {
+      const error = {
+        message: err.message,
+        data: err.data,
+        code: err.code
+      }
+      console.log('failed: ', 'rpc::res.send()', 'error:', JSON.stringify(error))
+    }
+  }
+
+  async handleRpc (reqItem: any): Promise<any> {
     const {
       method,
       params,
       jsonrpc,
       id
-    } = req.body
+    } = reqItem
     debug('>>', { jsonrpc, id, method, params })
     try {
       const result = deepHexlify(await this.handleMethod(method, params))
       console.log('sent', method, '-', result)
       debug('<<', { jsonrpc, id, result })
-      res.send({
+      return {
         jsonrpc,
         id,
         result
-      })
+      }
     } catch (err: any) {
       const error = {
         message: err.message,
@@ -121,12 +144,11 @@ export class BundlerServer {
       }
       console.log('failed: ', method, 'error:', JSON.stringify(error))
       debug('<<', { jsonrpc, id, error })
-
-      res.send({
+      return {
         jsonrpc,
         id,
         error
-      })
+      }
     }
   }
 


### PR DESCRIPTION
When using ethers.js (v6.6.1) to connect to the bundler RPC, running the code below inevitably leads to the error: `RpcError('Method undefined is not supported', -32601)`.

Sample code:

```typescript
import { ethers } from 'ethers';
async function main() {
	 const BUNDLER = 'http://127.0.0.1:3000/rpc';
   const supportedEntryPoint = await new ethers.JsonRpcProvider(BUNDLER).send('eth_supportedEntryPoints',[]);
   console.log(supportedEntryPoint);
}
main()
```

The reason for the error is that when the bundler receives a request from ethers.js (eth_supportedEntryPoints), it does not only receive the eth_supportedEntryPoints request but also receives an eth_chainId request. That is to say, when executing the function `async rpc (req: Request, res: Response)` in [BundlerServer.ts](https://github.com/eth-infinitism/bundler/blob/c8ac5b43ec6223601765f88dbf1afeefc68c9507/packages/bundler/src/BundlerServer.ts#L99-L104):

```typescript
const {
      method,
      params,
      jsonrpc,
      id
    } = req.body
```

There's a possibility of failure in parsing req.body, because in the situation described above, req.body is an array. The `Method undefined is not supported` error occurs because the data is not parsed as an array when req.body is an array.