### PR TITLE
adapt to eth_sendRawTransactionConditional

### DIFF
--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -101,6 +101,8 @@ export class BundleManager {
       } else {
         // ret = await this.signer.sendTransaction(tx)
         ret = await this.provider.send('eth_sendRawTransaction', [signedTx])
+        console.log('Type of signedTx:', typeof signedTx);
+        console.log('eth_sendRawTransactionConditional ret=', ret);
         debug('eth_sendRawTransaction ret=', ret)
       }
       // TODO: parse ret, and revert if needed.

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -89,12 +89,16 @@ export class BundleManager {
       const signedTx = await this.signer.signTransaction(tx)
       let ret: string
       if (this.conditionalRpc) {
+        const currentBlockNumber = await this.provider.getBlockNumber();
+        const min = currentBlockNumber;
+        const max = currentBlockNumber + 100;
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
-            blockNumberMin: '0x100'
+            blockNumberMin: min,
+            blockNumberMax: max
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -93,8 +93,7 @@ export class BundleManager {
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, JSON.stringify({ 
-            knownAccounts: storageMap,
-            blockNumberMin: "0x01"  
+            knownAccounts: storageMap
            })
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,7 +94,7 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
-            blockNumberMin: '0x01'
+            blockNumberMin: '0x1'
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -90,8 +90,8 @@ export class BundleManager {
       let ret: string
       if (this.conditionalRpc) {
         const currentBlockNumber = await this.provider.getBlockNumber();
-        const min = currentBlockNumber;
-        const max = currentBlockNumber + 100;
+        const min = '0x' + currentBlockNumber.toString(16);
+        const max = '0x' + (currentBlockNumber + 100).toString(16);
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,7 +94,7 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
-            blockNumberMin: '0x1'
+            blockNumberMin: 100
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -93,7 +93,7 @@ export class BundleManager {
         const min = '0x' + currentBlockNumber.toString(16);
         const max = '0x' + (currentBlockNumber + 100).toString(16);
         debug('eth_sendRawTransactionConditional', storageMap)
-        console.log('eth_sendRawTransactionConditional 1111', storageMap);
+        console.log('eth_sendRawTransactionConditional 1111', storageMap, 'block number 22212123', currentBlockNumber);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,7 +94,7 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, JSON.stringify({ 
             knownAccounts: storageMap,
-            blockNumberMin: "0x5678"  
+            blockNumberMin: "0x01"  
            })
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -92,7 +92,10 @@ export class BundleManager {
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
-          signedTx, JSON.stringify({ knownAccounts: storageMap })
+          signedTx, JSON.stringify({ 
+            knownAccounts: storageMap,
+            blockNumberMin: "0x5678"  
+           })
         ])
         console.log('signedTx:', signedTx);
         console.log('Type of signedTx:', typeof signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -93,7 +93,8 @@ export class BundleManager {
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
-            knownAccounts: storageMap
+            knownAccounts: storageMap,
+            blockNumberMin: "0x01"
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -93,7 +93,6 @@ export class BundleManager {
         const min = '0x' + currentBlockNumber.toString(16);
         const max = '0x' + (currentBlockNumber + 100).toString(16);
         debug('eth_sendRawTransactionConditional', storageMap)
-        console.log('eth_sendRawTransactionConditional 1111', storageMap, 'block number 22212123', currentBlockNumber);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
@@ -101,16 +100,10 @@ export class BundleManager {
             blockNumberMax: max
           }
         ])
-        console.log('signedTx:', signedTx);
-        console.log('Type of signedTx:', typeof signedTx);
-        console.log('eth_sendRawTransactionConditional ret=', ret);
         debug('eth_sendRawTransactionConditional ret=', ret)
       } else {
         // ret = await this.signer.sendTransaction(tx)
         ret = await this.provider.send('eth_sendRawTransaction', [signedTx])
-        console.log('signedTx:', signedTx);
-        console.log('Type of signedTx:', typeof signedTx);
-        console.log('eth_sendRawTransactionConditional ret=', ret);
         debug('eth_sendRawTransaction ret=', ret)
       }
       // TODO: parse ret, and revert if needed.

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -92,7 +92,7 @@ export class BundleManager {
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
-          signedTx, { knownAccounts: storageMap }
+          signedTx, JSON.stringify({ knownAccounts: storageMap })
         ])
         console.log('signedTx:', signedTx);
         console.log('Type of signedTx:', typeof signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -92,7 +92,9 @@ export class BundleManager {
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
-          signedTx, {knownAccounts: storageMap}
+          signedTx, JSON.stringify({ 
+            knownAccounts: storageMap
+           })
         ])
         console.log('signedTx:', signedTx);
         console.log('Type of signedTx:', typeof signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -90,9 +90,11 @@ export class BundleManager {
       let ret: string
       if (this.conditionalRpc) {
         debug('eth_sendRawTransactionConditional', storageMap)
+        console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, { knownAccounts: storageMap }
         ])
+        console.log('eth_sendRawTransactionConditional ret=', ret);
         debug('eth_sendRawTransactionConditional ret=', ret)
       } else {
         // ret = await this.signer.sendTransaction(tx)

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -101,6 +101,7 @@ export class BundleManager {
       } else {
         // ret = await this.signer.sendTransaction(tx)
         ret = await this.provider.send('eth_sendRawTransaction', [signedTx])
+        console.log('signedTx:', signedTx);
         console.log('Type of signedTx:', typeof signedTx);
         console.log('eth_sendRawTransactionConditional ret=', ret);
         debug('eth_sendRawTransaction ret=', ret)

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -92,9 +92,7 @@ export class BundleManager {
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
-          signedTx, JSON.stringify({ 
-            knownAccounts: storageMap
-           })
+          signedTx, {knownAccounts: storageMap}
         ])
         console.log('signedTx:', signedTx);
         console.log('Type of signedTx:', typeof signedTx);
@@ -246,7 +244,9 @@ export class BundleManager {
       // If sender's account already exist: replace with its storage root hash
       if (this.mergeToAccountRootHash && this.conditionalRpc && entry.userOp.initCode.length <= 2) {
         const { storageHash } = await this.provider.send('eth_getProof', [entry.userOp.sender, [], 'latest'])
-        storageMap[entry.userOp.sender.toLowerCase()] = storageHash
+        storageMap[entry.userOp.sender.toLowerCase()] = {
+          StorageRoot: storageHash
+        };
       }
       mergeStorageMap(storageMap, validationResult.storageMap)
 

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,7 +94,7 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
-            blockNumberMin: 100
+            blockNumberMin: '0x100'
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,6 +94,8 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, { knownAccounts: storageMap }
         ])
+        console.log('signedTx:', signedTx);
+        console.log('Type of signedTx:', typeof signedTx);
         console.log('eth_sendRawTransactionConditional ret=', ret);
         debug('eth_sendRawTransactionConditional ret=', ret)
       } else {

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,7 +94,7 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
-            blockNumberMin: 0x01
+            blockNumberMin: '0x01'
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -94,7 +94,7 @@ export class BundleManager {
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
           signedTx, {
             knownAccounts: storageMap,
-            blockNumberMin: "0x01"
+            blockNumberMin: 0x01
           }
         ])
         console.log('signedTx:', signedTx);

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -92,9 +92,9 @@ export class BundleManager {
         debug('eth_sendRawTransactionConditional', storageMap)
         console.log('eth_sendRawTransactionConditional 1111', storageMap);
         ret = await this.provider.send('eth_sendRawTransactionConditional', [
-          signedTx, JSON.stringify({ 
+          signedTx, {
             knownAccounts: storageMap
-           })
+          }
         ])
         console.log('signedTx:', signedTx);
         console.log('Type of signedTx:', typeof signedTx);

--- a/packages/bundler/src/modules/Types.ts
+++ b/packages/bundler/src/modules/Types.ts
@@ -42,6 +42,11 @@ export interface SlotMap {
  * map of storage
  * for each address, either a root hash, or a map of slot:value
  */
+export interface KnownAccount {
+  StorageRoot?: string;
+  StorageSlots?: SlotMap;
+}
+
 export interface StorageMap {
-  [address: string]: string | SlotMap
+  [address: string]: KnownAccount;
 }

--- a/packages/bundler/src/modules/moduleUtils.ts
+++ b/packages/bundler/src/modules/moduleUtils.ts
@@ -49,8 +49,8 @@ export function mergeStorageMap(mergedStorageMap: StorageMap, validationStorageM
         });
       }
     }
-  });
-  return mergedStorageMap;
+  })
+  return mergedStorageMap
 }
 
 export function toBytes32 (b: BytesLike | number): string {

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -106,7 +106,7 @@ export async function runBundler (argv: string[], overrideExit = true): Promise<
     }
   }
 
-  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', ['0x', {}])) {
+  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', [{}, {}])) {
     console.error('FATAL: --conditionalRpc requires a node that support eth_sendRawTransactionConditional')
     process.exit(1)
   }

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -106,7 +106,7 @@ export async function runBundler (argv: string[], overrideExit = true): Promise<
     }
   }
 
-  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', [{}, {}])) {
+  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', [0x0, {}])) {
     console.error('FATAL: --conditionalRpc requires a node that support eth_sendRawTransactionConditional')
     process.exit(1)
   }

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -106,7 +106,7 @@ export async function runBundler (argv: string[], overrideExit = true): Promise<
     }
   }
 
-  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', ['0x0', {}])) {
+  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', ['0x', {}])) {
     console.error('FATAL: --conditionalRpc requires a node that support eth_sendRawTransactionConditional')
     process.exit(1)
   }

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -106,7 +106,7 @@ export async function runBundler (argv: string[], overrideExit = true): Promise<
     }
   }
 
-  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', [0x0, {}])) {
+  if (config.conditionalRpc && !await supportsRpcMethod(provider as any, 'eth_sendRawTransactionConditional', ['0x0', {}])) {
     console.error('FATAL: --conditionalRpc requires a node that support eth_sendRawTransactionConditional')
     process.exit(1)
   }


### PR DESCRIPTION
1.  The structure of knownAccounts is different, and an error will be reported when using it.
[knownAccounts](https://github.com/ethereum/go-ethereum/compare/master...joohhnnn:go-ethereum:eip4337Help#diff-aa2f8b6f5f1dbb32141ae75d1651e332ceec674cba802eec206757c2b93dc382R114)
2. Added other examples such as blockNumberMin.
3. An error occurs in the RPC when checking whether the eth_sendRawTransactionConditional method exists, and I will fix it in the next PR. Perhaps use another method such as 
`const supportedMethods = await provider.send('rpc_modules');` to get the result?
<img width="1505" alt="image" src="https://github.com/eth-infinitism/bundler/assets/68833933/fba28ec7-fee3-4134-ae6a-8ef6148c6d8f">


you can use this GETH [patch](https://github.com/ethereum/go-ethereum/compare/master...joohhnnn:go-ethereum:eip4337Help) to test 

use the below command to start GETH
`geth --miner.gaslimit 12000000 --http --http.api personal,eth,net,web3,debug --http.vhosts '*,localhost,host.docker.internal' --http.addr "0.0.0.0"  --allow-insecure-unlock --rpc.allow-unprotected-txs --dev --verbosity 2 --nodiscover --maxpeers 0 --mine --miner.threads 1 --networkid 1337`


