### PR TITLE
fix bignumber comparison

### DIFF
--- a/packages/bundler/src/UserOpMethodHandler.ts
+++ b/packages/bundler/src/UserOpMethodHandler.ts
@@ -137,10 +137,10 @@ export class UserOpMethodHandler {
     })
     validAfter = BigNumber.from(validAfter)
     validUntil = BigNumber.from(validUntil)
-    if (validUntil === BigNumber.from(0)) {
+    if ((validUntil as BigNumber).eq(0)) {
       validUntil = undefined
     }
-    if (validAfter === BigNumber.from(0)) {
+    if ((validAfter as BigNumber).eq(0)) {
       validAfter = undefined
     }
     const preVerificationGas = calcPreVerificationGas(userOp)

--- a/packages/bundler/src/parseScannerResult.ts
+++ b/packages/bundler/src/parseScannerResult.ts
@@ -191,8 +191,7 @@ export function parseScannerResult (userOp: UserOperation, tracerResults: Bundle
   )
 
   requireCond(
-    callStack.find(call => call.to !== entryPointAddress &&
-      BigNumber.from(call.value ?? 0) !== BigNumber.from(0)) != null,
+    callStack.find(call => call.to !== entryPointAddress && !BigNumber.from(call.value ?? 0).eq(0)) != null,
     'May not may CALL with value',
     ValidationErrors.OpcodeValidation)
 


### PR DESCRIPTION
BigNumber.from() returns an object and so `==` compares the pointer address and not the value of the object

![image](https://github.com/eth-infinitism/bundler/assets/7760339/defdb765-fabf-4298-b5ab-f62615c59fdb)

source: https://playground.ethers.org/