### PR TITLE
AA-192: fix 'yarn runop' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "bundler": "yarn --cwd packages/bundler bundler",
-    "runop": "yarn --cwd packages/bundler runop --deployFactory",
+    "runop": "yarn --cwd packages/bundler runop",
     "runop-goerli": "yarn runop --network goerli --unsafe",
     "create-all-deps": "jq '.dependencies,.devDependencies' packages/*/package.json |sort  -u > all.deps",
     "depcheck": "lerna exec --no-bail --stream --parallel -- npx depcheck",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "bundler": "yarn --cwd packages/bundler bundler",
-    "runop": "yarn --cwd packages/bundler runop",
+    "runop": "yarn --cwd packages/bundler runop --deployFactory",
     "runop-goerli": "yarn runop --network goerli --unsafe",
     "create-all-deps": "jq '.dependencies,.devDependencies' packages/*/package.json |sort  -u > all.deps",
     "depcheck": "lerna exec --no-bail --stream --parallel -- npx depcheck",

--- a/packages/bundler/src/runner/runop.ts
+++ b/packages/bundler/src/runner/runop.ts
@@ -173,7 +173,7 @@ async function main (): Promise<void> {
   console.log('account address', addr, 'deployed=', await isDeployed(addr), 'bal=', formatEther(bal))
   const gasPrice = await provider.getGasPrice()
   // TODO: actual required val
-  const requiredBalance = gasPrice.mul(2e6)
+  const requiredBalance = gasPrice.mul(4e6)
   if (bal.lt(requiredBalance.div(2))) {
     console.log('funding account to', requiredBalance.toString())
     await signer.sendTransaction({

--- a/packages/bundler/src/runner/runop.ts
+++ b/packages/bundler/src/runner/runop.ts
@@ -113,7 +113,7 @@ async function main (): Promise<void> {
   const opts = program.parse().opts()
   const provider = getNetworkProvider(opts.network)
   let signer: Signer
-  const deployFactory: boolean = opts.deployFactory
+  let deployFactory: boolean = opts.deployFactory
   let bundler: BundlerServer | undefined
   if (opts.selfBundler != null) {
     // todo: if node is geth, we need to fund our bundler's account:
@@ -148,7 +148,10 @@ async function main (): Promise<void> {
       }
       // for hardhat/node, use account[0]
       signer = provider.getSigner()
-      // deployFactory = true
+      const network = await provider.getNetwork()
+      if (network.chainId === 1337 || network.chainId === 31337) {
+        deployFactory = true
+      }
     } catch (e) {
       throw new Error('must specify --mnemonic')
     }


### PR DESCRIPTION
1. We can always pass a "--deployFactory" flag. It doesn't work without.

2. There is no real estimation of "requiredBalance" so using hard-coded.