### PR TITLE
Fix rpc endpoint: debug_bundler_setReputation

### DIFF
--- a/packages/bundler/src/DebugMethodHandler.ts
+++ b/packages/bundler/src/DebugMethodHandler.ts
@@ -51,10 +51,10 @@ export class DebugMethodHandler {
   }
 
   setReputation (param: any): ReputationDump {
-    if (param.reputation == null) {
-      throw new Error('expected structure { reputation: {addr:{opsSeen:1, opsIncluded:2} }')
+    if (param.reputations == null) {
+      throw new Error('expected structure { reputations: [{address: address, opsSeen:1, opsIncluded:2, status: "ok"}] }')
     }
-    return this.repManager.setReputation(param)
+    return this.repManager.setReputation(param.reputations)
   }
 
   dumpReputation (): ReputationDump {

--- a/packages/bundler/src/modules/ReputationManager.ts
+++ b/packages/bundler/src/modules/ReputationManager.ts
@@ -178,7 +178,8 @@ export class ReputationManager {
       this.entries[rep.address] = {
         address: rep.address,
         opsSeen: rep.opsSeen,
-        opsIncluded: rep.opsIncluded
+        opsIncluded: rep.opsIncluded,
+        status: rep.status
       }
     })
     return this.dump()


### PR DESCRIPTION
RPC endpoint, `debug_bundler_setReputation` was not working properly. This PR will resolve the issue.

Here's a bash command that can be used to test it.

```
curl --location 'http://localhost:3000/rpc' \
--header 'Content-Type: application/json' \
--data '{
    "method": "debug_bundler_setReputation",
    "params": [{
        "reputations": [{
            "address": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
            "opsSeen": 1,
            "opsIncluded": 10,
            "status": "ok"
        }]
    }],
    "jsonrpc": "2.0",
    "id": 1
}'
```

The response will be:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "ok"
}
```