### PR TITLE
minimal support for reth

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "bundler": "yarn --cwd packages/bundler bundler",
     "runop": "yarn --cwd packages/bundler runop",
+    "runop-mnemonic": "yarn --cwd packages/bundler runop-mnemonic",
     "runop-goerli": "yarn runop --network goerli --unsafe",
     "create-all-deps": "jq '.dependencies,.devDependencies' packages/*/package.json |sort  -u > all.deps",
     "depcheck": "lerna exec --no-bail --stream --parallel -- npx depcheck",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "runop": "ts-node ./src/runner/runop.ts",
+    "runop-mnemonic": "ts-node ./src/runner/runop.ts --mnemonic ./localconfig/mnemonic.txt",
     "bundler": "ts-node ./src/exec.ts --config ./localconfig/bundler.config.json",
     "clear": "rm -rf dist artifacts cache src/types",
     "hardhat-compile": "hardhat compile",

--- a/packages/bundler/src/runBundler.ts
+++ b/packages/bundler/src/runBundler.ts
@@ -105,7 +105,16 @@ export async function runBundler (argv: string[], overrideExit = true): Promise<
     } else {
       console.log('== debugrpc already st', config.debugRpc)
     }
-    await new DeterministicDeployer(provider as any).deterministicDeploy(EntryPoint__factory.bytecode)
+    let deploySigner: Signer
+    try {
+      // on test network, try to use "eth_accounts[0]".
+      deploySigner = (provider as JsonRpcProvider).getSigner()
+      await deploySigner.getAddress()
+    } catch (e) {
+      // if eth_accounts is not supported (e.g. on reth), use our mnemonic-based wallet instead
+      deploySigner = Wallet.fromMnemonic('blood scheme ghost kit twin save film relief neutral where account battle').connect(provider)
+    }
+    await new DeterministicDeployer(provider as any, deploySigner).deterministicDeploy(EntryPoint__factory.bytecode)
     if ((await wallet.getBalance()).eq(0)) {
       console.log('=== testnet: fund signer')
       const signer = (provider as JsonRpcProvider).getSigner()

--- a/packages/sdk/src/BaseAccountAPI.ts
+++ b/packages/sdk/src/BaseAccountAPI.ts
@@ -247,10 +247,10 @@ export abstract class BaseAccountAPI {
     if (maxFeePerGas == null || maxPriorityFeePerGas == null) {
       const feeData = await this.provider.getFeeData()
       if (maxFeePerGas == null) {
-        maxFeePerGas = feeData.maxFeePerGas ?? undefined
+        maxFeePerGas = feeData.maxFeePerGas ?? feeData.gasPrice ?? undefined
       }
       if (maxPriorityFeePerGas == null) {
-        maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined
+        maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? feeData.gasPrice ?? undefined
       }
     }
 


### PR DESCRIPTION
add minimal support for using reth as node.
1. reth doesn't have eth_accounts even in debug. so on debug network bundler uses mnemonic-based account to deploy EntryPoint
2. getFeeData doesn't return maxPriorityFee/maxFeePerGas, so we use the returned gasPrice instead
3. running "runop" requires mnemonic (because of "1" above)

running reth with: `reth node --dev --http.api=debug,eth,net,web3`
running bundler: `yarn bundler`
running test app: `yarn runop-mnemonic`

Currently, the above fails with error: "Invalid response. simulateCall must revert"
Running the above with `geth` doesn't fail, so it is failed processing of `reth` of the tracer.
(note that to run `geth` you need to use `yarn runop`, without the mnemonic)