### PR TITLE
add process signal handlers and specify package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/bundler/src/exec.ts
+++ b/packages/bundler/src/exec.ts
@@ -1,6 +1,18 @@
 import { runBundler, showStackTraces } from './runBundler'
 
-void runBundler(process.argv)
+process.on('SIGINT', () => {
+  process.exit(0)
+})
+
+process.on('SIGTERM', () => {
+  process.exit(0)
+})
+
+void runBundler(process.argv).then((bundler) => {
+  process.on('exit', () => {
+    void bundler.stop()
+  })
+})
   .catch(e => {
     console.error('Aborted:', showStackTraces ? e : e.message)
     process.exit(1)


### PR DESCRIPTION
Thank you for publishing this bundler implementation. I found these changes helpful when working in the local environment and when running the bundler via docker environment. Otherwise, the docker container would need to be force killed to stop running.