### PR TITLE
use INVALID_PARAMS_CODE instead of METHOD_NOT_FOUND for bad userOpHash

### DIFF
--- a/packages/bundler/src/UserOpMethodHandler.ts
+++ b/packages/bundler/src/UserOpMethodHandler.ts
@@ -201,7 +201,7 @@ export class UserOpMethodHandler {
   }
 
   async getUserOperationByHash (userOpHash: string): Promise<UserOperationByHashResponse | null> {
-    requireCond(userOpHash?.toString()?.match(HEX_REGEX) != null, 'Missing/invalid userOpHash', -32601)
+    requireCond(userOpHash?.toString()?.match(HEX_REGEX) != null, 'Missing/invalid userOpHash', -32602)
     const event = await this._getUserOperationEvent(userOpHash)
     if (event == null) {
       return null
@@ -259,7 +259,7 @@ export class UserOpMethodHandler {
   }
 
   async getUserOperationReceipt (userOpHash: string): Promise<UserOperationReceipt | null> {
-    requireCond(userOpHash?.toString()?.match(HEX_REGEX) != null, 'Missing/invalid userOpHash', -32601)
+    requireCond(userOpHash?.toString()?.match(HEX_REGEX) != null, 'Missing/invalid userOpHash', -32602)
     const event = await this._getUserOperationEvent(userOpHash)
     if (event == null) {
       return null


### PR DESCRIPTION
- Change error code from -32601 to -32602  for invalid or missing `userOpHash` so that the reference bundler is in line with spec test change: https://github.com/eth-infinitism/bundler-spec-tests/pull/51