### PR TITLE
fix intermittent "not enough funds" to deploy the deterministic deployer

### DIFF
--- a/packages/utils/src/DeterministicDeployer.ts
+++ b/packages/utils/src/DeterministicDeployer.ts
@@ -67,7 +67,7 @@ export class DeterministicDeployer {
         to: DeterministicDeployer.deploymentSignerAddress,
         value: neededBalance,
         gasLimit: DeterministicDeployer.deploymentGasLimit
-      })
+      }).then(t=>t.wait())
     }
     await this.provider.send('eth_sendRawTransaction', [DeterministicDeployer.deploymentTransaction])
     if (!await this.isContractDeployed(DeterministicDeployer.proxyAddress)) {


### PR DESCRIPTION
annoying bundler crash on startup (which works on 2nd run) only if the deterministic deployer is not yet deployed (that is, just after starting geth)