### PR TITLE
fix revert reason decoding for Hardhat networks

### DIFF
--- a/packages/utils/src/decodeRevertReason.ts
+++ b/packages/utils/src/decodeRevertReason.ts
@@ -16,7 +16,7 @@ const decodeRevertReasonContracts = new Interface([
 export function decodeRevertReason (data: string | Error, nullIfNoMatch = true): string | null {
   if (typeof data !== 'string') {
     const err = data as any
-    data = (err.data?.data ?? err.data ?? err.error.data) as string
+    data = (err.data?.data ?? err.data ?? err.error.data?.data ?? err.error.data) as string
   }
   const methodSig = data.slice(0, 10)
   const dataParams = '0x' + data.slice(10)


### PR DESCRIPTION
This fixes the `eth_sendUserOperation error: {"message":"data.slice is not a function"}` error seen when running the bundler against a Hardhat node.