### PR TITLE
AA-650 invalid block while reading logs

### DIFF
--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@account-abstraction/bundler",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "private": true,
   "files": [

--- a/packages/bundler/src/modules/EventsManager.ts
+++ b/packages/bundler/src/modules/EventsManager.ts
@@ -39,9 +39,16 @@ export class EventsManager {
     if (this.lastBlock === undefined) {
       this.lastBlock = Math.max(1, await this.entryPoint.provider.getBlockNumber() - 1000)
     }
-    const events = await this.entryPoint.queryFilter({ address: this.entryPoint.address }, this.lastBlock)
-    for (const ev of events) {
-      this.handleEvent(ev)
+    try {
+      const events = await this.entryPoint.queryFilter({ address: this.entryPoint.address }, this.lastBlock)
+      for (const ev of events) {
+        this.handleEvent(ev)
+      }
+    } catch (e) {
+      // if we processed latest block, then "lastBlock" is set to one above, so the new geth 15.9 error can safely be ignored.
+      if (!(e as Error).message.includes('invalid block range params')) {
+        throw e
+      }
     }
   }
 


### PR DESCRIPTION
with latest geth (15.9 to be exact) eth_getLogs aborts if "from block" is a future block.
This is a perfectly valid state, if we processed all events from the latest block.